### PR TITLE
Fix static UI path and serialize captura responses

### DIFF
--- a/sirep/domain/schemas.py
+++ b/sirep/domain/schemas.py
@@ -1,6 +1,8 @@
 from datetime import date, datetime
+from typing import List, Optional
+
 from pydantic import BaseModel
-from typing import Optional, List
+
 from .enums import PlanStatus, Step
 
 class PlanIn(BaseModel):
@@ -34,6 +36,20 @@ class PlanOut(BaseModel):
     dt_parcela_atraso: Optional[date] = None
     representacao: Optional[str] = None
     status: PlanStatus
+
+    class Config:
+        from_attributes = True
+
+
+class DiscardedPlanOut(BaseModel):
+    id: int
+    numero_plano: str
+    situacao: str
+    cnpj: str
+    tipo: Optional[str] = None
+    saldo: Optional[float] = None
+    dt_situacao_atual: Optional[date] = None
+    created_at: datetime
 
     class Config:
         from_attributes = True

--- a/tests/test_captura_endpoints.py
+++ b/tests/test_captura_endpoints.py
@@ -1,0 +1,64 @@
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+from sirep.app.api import app
+from sirep.domain.models import DiscardedPlan, Plan
+from sirep.infra.db import SessionLocal, init_db
+
+
+@pytest.fixture
+def client_with_data():
+    init_db()
+    with SessionLocal() as db:
+        db.query(DiscardedPlan).delete()
+        db.query(Plan).delete()
+        db.commit()
+
+        plan = Plan(
+            numero_plano="0001",
+            situacao_atual="P. RESC",
+            saldo=123.45,
+            status="NOVO",
+        )
+        db.add(plan)
+
+        discarded = DiscardedPlan(
+            numero_plano="0002",
+            situacao="ERRO_PROCESSAMENTO",
+            cnpj="12.345.678/0001-90",
+            tipo="TESTE",
+            saldo=67.89,
+            dt_situacao_atual=date(2023, 1, 1),
+        )
+        db.add(discarded)
+        db.commit()
+
+    with TestClient(app) as client:
+        yield client
+
+
+def test_captura_planos_returns_serializable(client_with_data):
+    response = client_with_data.get("/captura/planos")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["total"] == 1
+    assert payload["total_passiveis"] == 1
+    assert payload["items"]
+    first = payload["items"][0]
+    assert first["numero_plano"] == "0001"
+    assert first["status"] == "NOVO"
+
+
+def test_captura_ocorrencias_returns_serializable(client_with_data):
+    response = client_with_data.get("/captura/ocorrencias")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["total"] == 1
+    assert payload["items"]
+    first = payload["items"][0]
+    assert first["numero_plano"] == "0002"
+    assert first["situacao"] == "ERRO_PROCESSAMENTO"


### PR DESCRIPTION
## Summary
- resolve the FastAPI static files mount by pointing to the packaged UI directory
- serialize Plan and DiscardedPlan ORM objects through Pydantic schemas before returning JSON
- add API tests that seed sample data and verify the captura endpoints return JSON-serializable payloads

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ce78d96e5c83238016ebd4c29a8d58