### PR TITLE
Ordena ocorrências por saldo

### DIFF
--- a/sirep/app/api.py
+++ b/sirep/app/api.py
@@ -117,7 +117,10 @@ def captura_planos(pagina: int = 1, tamanho: int = 10):
 def captura_ocorrencias(pagina: int = 1, tamanho: int = 10):
     db = SessionLocal()
     try:
-        q = db.query(DiscardedPlan).order_by(DiscardedPlan.id.desc())
+        q = db.query(DiscardedPlan).order_by(
+            DiscardedPlan.saldo.desc().nullslast(),
+            DiscardedPlan.id.desc(),
+        )
         total = q.count()
         raw_items = q.offset((pagina - 1) * tamanho).limit(tamanho).all()
         items = [

--- a/tests/test_captura_endpoints.py
+++ b/tests/test_captura_endpoints.py
@@ -24,7 +24,15 @@ def client_with_data():
         )
         db.add(plan)
 
-        discarded = DiscardedPlan(
+        discarded_high = DiscardedPlan(
+            numero_plano="0003",
+            situacao="ERRO_PROCESSAMENTO",
+            cnpj="23.456.789/0001-01",
+            tipo="TESTE",
+            saldo=250.0,
+            dt_situacao_atual=date(2023, 1, 2),
+        )
+        discarded_mid = DiscardedPlan(
             numero_plano="0002",
             situacao="ERRO_PROCESSAMENTO",
             cnpj="12.345.678/0001-90",
@@ -32,7 +40,15 @@ def client_with_data():
             saldo=67.89,
             dt_situacao_atual=date(2023, 1, 1),
         )
-        db.add(discarded)
+        discarded_none = DiscardedPlan(
+            numero_plano="0004",
+            situacao="ERRO_PROCESSAMENTO",
+            cnpj="34.567.890/0001-12",
+            tipo="TESTE",
+            saldo=None,
+            dt_situacao_atual=date(2023, 1, 3),
+        )
+        db.add_all([discarded_high, discarded_mid, discarded_none])
         db.commit()
 
     with TestClient(app) as client:
@@ -57,8 +73,10 @@ def test_captura_ocorrencias_returns_serializable(client_with_data):
     assert response.status_code == 200
     payload = response.json()
 
-    assert payload["total"] == 1
+    assert payload["total"] == 3
     assert payload["items"]
-    first = payload["items"][0]
-    assert first["numero_plano"] == "0002"
-    assert first["situacao"] == "ERRO_PROCESSAMENTO"
+    numeros = [item["numero_plano"] for item in payload["items"]]
+    assert numeros == ["0003", "0002", "0004"]
+    assert payload["items"][0]["saldo"] == 250.0
+    assert payload["items"][1]["saldo"] == 67.89
+    assert payload["items"][2]["saldo"] is None


### PR DESCRIPTION
## Summary
- ordena os planos descartados pelo saldo de forma decrescente, alinhando a aba de ocorrências com a de planos capturados
- ajusta os testes de captura para cobrir a nova ordenação e o tratamento de saldos nulos

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce9408a758832395cc07937f7b7bfa