### PR TITLE
Manter histórico do painel de eventos em tempo real

### DIFF
--- a/sirep/app/api.py
+++ b/sirep/app/api.py
@@ -90,6 +90,16 @@ async def captura_status():
             {"numero_plano": p.numero_plano, "progresso": p.progresso, "etapas": p.etapas}
             for p in st.em_progresso.values()
         ],
+        "historico": [
+            {
+                "numero_plano": h.numero_plano,
+                "mensagem": h.mensagem,
+                "progresso": h.progresso,
+                "etapa": h.etapa,
+                "timestamp": h.timestamp,
+            }
+            for h in st.historico
+        ],
         "ultima_atualizacao": st.ultima_atualizacao,
         "ocorrencias_total": ocorrencias_total,
         "total": total,

--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -30,6 +30,9 @@
     th{text-align:left;font-size:12px;color:#4b5563} .right{text-align:right}
     .grid{display:grid;grid-template-columns:1fr 320px;gap:16px} @media (max-width:980px){.grid{grid-template-columns:1fr}}
     .log{border:1px solid var(--line);border-radius:10px;padding:10px;height:320px;overflow:auto;background:#fafafa}
+    .log p{margin:0 0 6px}
+    .log .log-active{font-weight:600}
+    .log .log-history{color:var(--muted);font-size:12px}
     .footer{display:flex;justify-content:space-between;align-items:center;margin-top:8px}
     .state{font-weight:700}
     /* sub-abas dentro da seção */
@@ -245,19 +248,35 @@ async function carregarOcorrencias(){
   updateFooterOcc(totalRegistros>0);
 }
 
-function renderEmProgresso(list){
-  el.log.innerHTML=""; list.forEach(item=>{
+function renderLog(emProgresso, historico){
+  el.log.innerHTML="";
+  const frag=document.createDocumentFragment();
+  emProgresso.forEach(item=>{
     const p=Math.min(4,Math.max(0,item.progresso));
     const pct=Math.round((p/4)*100);
-    const div=document.createElement("p"); div.textContent=`${item.numero_plano} — ${pct}% (${item.etapas[p-1]||"Início"})`;
-    el.log.appendChild(div);
-  }); el.log.scrollTop=el.log.scrollHeight;
+    const etapa=item.etapas[p-1]||"Início";
+    const div=document.createElement("p");
+    div.textContent=`${item.numero_plano} — ${pct}% (${etapa})`;
+    div.classList.add("log-active");
+    frag.appendChild(div);
+  });
+  historico.forEach(item=>{
+    const div=document.createElement("p");
+    const etapa=item.etapa?` (${item.etapa})`:"";
+    const hora=item.timestamp?new Date(item.timestamp).toLocaleTimeString("pt-BR",{hour:"2-digit",minute:"2-digit"}):"";
+    const prefix=hora?`[${hora}] `:"";
+    div.textContent=`${prefix}${item.numero_plano} — ${item.mensagem}${etapa}`;
+    div.classList.add("log-history");
+    frag.appendChild(div);
+  });
+  el.log.appendChild(frag);
+  el.log.scrollTop=el.log.scrollHeight;
 }
 
 async function carregarStatus(){
   const s=await api("/captura/status");
   stateButtons(s.estado); setBar(s.progresso_total);
-  renderEmProgresso(s.em_progresso||[]);
+  renderLog(s.em_progresso||[], s.historico||[]);
   el.ultima.textContent="Última atualização: "+(s.ultima_atualizacao?new Date(s.ultima_atualizacao).toLocaleString("pt-BR"):"—");
   el.badgeOcorr.textContent = s.ocorrencias_total ?? 0;
 }


### PR DESCRIPTION
## Summary
- registrar eventos concluídos e descartados no serviço de captura mantendo um histórico limitado
- expor o histórico no endpoint de status da captura
- atualizar o painel lateral da interface para exibir o histórico com timestamp e estilos dedicados

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce96ff5ca08323a344f21c7106dccf