### PR TITLE
Preserve capture history and improve event log UX

### DIFF
--- a/sirep/app/captura.py
+++ b/sirep/app/captura.py
@@ -123,7 +123,14 @@ class CapturaService:
         if self._status.estado in ("executando", "pausado"):
             logger.info("captura já em %s", self._status.estado)
             return
-        self._status = CapturaStatus(estado="executando")
+
+        historico_anterior = list(self._status.historico)
+        ultima_atualizacao = self._status.ultima_atualizacao
+        self._status = CapturaStatus(
+            estado="executando",
+            historico=historico_anterior,
+            ultima_atualizacao=ultima_atualizacao,
+        )
 
         loop = self._ensure_loop()
         def prepare_events() -> None:
@@ -196,6 +203,12 @@ class CapturaService:
         finally:
             if self._status.estado != "pausado":
                 self._status.estado = "concluido"
+                self._registrar_historico(
+                    numero_plano="",
+                    progresso=4,
+                    etapa="",
+                    mensagem="Processamento concluído.",
+                )
             self._loop_task = None
             self._pause_evt = None
             self._stop_evt = None

--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -248,29 +248,47 @@ async function carregarOcorrencias(){
   updateFooterOcc(totalRegistros>0);
 }
 
-function renderLog(emProgresso, historico){
-  el.log.innerHTML="";
+function formatLogMessage(item){
+  const hora=item.timestamp?new Date(item.timestamp).toLocaleTimeString("pt-BR",{hour:"2-digit",minute:"2-digit"}):"";
+  const numero=(item.numero_plano||"").trim();
+  const mensagem=(item.mensagem||"").trim();
+  let corpo="";
+  if(mensagem==="Capturado com sucesso"&&numero){
+    corpo=`${numero} processado com sucesso.`;
+  }else if(mensagem.startsWith("Descartado")&&numero){
+    corpo=`${numero} possui ocorrência.`;
+  }else if(mensagem==="Falha inesperada"&&numero){
+    corpo=`${numero} falhou no processamento.`;
+  }else if(mensagem){
+    corpo=numero?`${numero} — ${mensagem}`:mensagem;
+  }else{
+    corpo=numero;
+  }
+  if(!corpo) return "";
+  return hora?`[${hora}] ${corpo}`:corpo;
+}
+
+function renderLog(_emProgresso, historico){
+  const container=el.log;
+  const prevScrollTop=container.scrollTop;
+  const nearBottom=(container.scrollHeight - (container.scrollTop + container.clientHeight))<=8;
+  container.innerHTML="";
   const frag=document.createDocumentFragment();
-  emProgresso.forEach(item=>{
-    const p=Math.min(4,Math.max(0,item.progresso));
-    const pct=Math.round((p/4)*100);
-    const etapa=item.etapas[p-1]||"Início";
-    const div=document.createElement("p");
-    div.textContent=`${item.numero_plano} — ${pct}% (${etapa})`;
-    div.classList.add("log-active");
-    frag.appendChild(div);
-  });
   historico.forEach(item=>{
+    const texto=formatLogMessage(item);
+    if(!texto) return;
     const div=document.createElement("p");
-    const etapa=item.etapa?` (${item.etapa})`:"";
-    const hora=item.timestamp?new Date(item.timestamp).toLocaleTimeString("pt-BR",{hour:"2-digit",minute:"2-digit"}):"";
-    const prefix=hora?`[${hora}] `:"";
-    div.textContent=`${prefix}${item.numero_plano} — ${item.mensagem}${etapa}`;
+    div.textContent=texto;
     div.classList.add("log-history");
     frag.appendChild(div);
   });
-  el.log.appendChild(frag);
-  el.log.scrollTop=el.log.scrollHeight;
+  container.appendChild(frag);
+  if(nearBottom){
+    container.scrollTop=container.scrollHeight;
+  }else{
+    const maxScroll=Math.max(0,container.scrollHeight-container.clientHeight);
+    container.scrollTop=Math.min(prevScrollTop,maxScroll);
+  }
 }
 
 async function carregarStatus(){


### PR DESCRIPTION
## Summary
- keep previous capture history when restarting and register a completion log entry
- rework the event log rendering to use the new message copy and stop showing progress rows
- preserve manual scroll position so earlier events stay accessible while new ones arrive

## Testing
- PYTHONPATH=$PWD pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce9a8b6ee48323a55d08e771a763c2