### PR TITLE
Adiciona data/hora e eventos de controle ao histórico

### DIFF
--- a/sirep/app/captura.py
+++ b/sirep/app/captura.py
@@ -132,6 +132,13 @@ class CapturaService:
             ultima_atualizacao=ultima_atualizacao,
         )
 
+        self._registrar_historico(
+            numero_plano="",
+            progresso=0,
+            etapa="",
+            mensagem="Processamento iniciado.",
+        )
+
         loop = self._ensure_loop()
         def prepare_events() -> None:
             self._pause_evt = asyncio.Event()
@@ -160,6 +167,12 @@ class CapturaService:
         self._status.estado = "pausado"
         if self._pause_evt is not None:
             self._run_on_loop(self._pause_evt.clear)
+        self._registrar_historico(
+            numero_plano="",
+            progresso=0,
+            etapa="",
+            mensagem="Processamento pausado.",
+        )
         logger.info("captura pausada")
 
     def continuar(self) -> None:
@@ -168,6 +181,12 @@ class CapturaService:
         self._status.estado = "executando"
         if self._pause_evt is not None:
             self._run_on_loop(self._pause_evt.set)
+        self._registrar_historico(
+            numero_plano="",
+            progresso=0,
+            etapa="",
+            mensagem="Processamento retomado.",
+        )
         logger.info("captura continuada")
 
     async def _run(self) -> None:

--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -249,7 +249,10 @@ async function carregarOcorrencias(){
 }
 
 function formatLogMessage(item){
-  const hora=item.timestamp?new Date(item.timestamp).toLocaleTimeString("pt-BR",{hour:"2-digit",minute:"2-digit"}):"";
+  const dataHora=item.timestamp?
+    new Date(item.timestamp).toLocaleString("pt-BR",{
+      day:"2-digit",month:"2-digit",year:"numeric",hour:"2-digit",minute:"2-digit"
+    }):"";
   const numero=(item.numero_plano||"").trim();
   const mensagem=(item.mensagem||"").trim();
   let corpo="";
@@ -265,7 +268,7 @@ function formatLogMessage(item){
     corpo=numero;
   }
   if(!corpo) return "";
-  return hora?`[${hora}] ${corpo}`:corpo;
+  return dataHora?`[${dataHora}] ${corpo}`:corpo;
 }
 
 function renderLog(_emProgresso, historico){


### PR DESCRIPTION
## Summary
- registra eventos de início, pausa e retomada diretamente no histórico da captura
- apresenta data e hora completas em cada linha do card de eventos da interface

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cea24f2cd08323a5a8d11e989eeb82