### PR TITLE
Persistir histórico da captura

### DIFF
--- a/sirep/domain/models.py
+++ b/sirep/domain/models.py
@@ -36,6 +36,16 @@ class Event(Base):
     level = Column(String(16), nullable=False, default="INFO")
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
+class CaptureEvent(Base):
+    __tablename__ = "capture_events"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    numero_plano = Column(String(32), nullable=False)
+    mensagem = Column(String(255), nullable=False)
+    progresso = Column(Integer, nullable=False)
+    etapa = Column(String(64), nullable=False)
+    timestamp = Column(DateTime(timezone=True), nullable=False, index=True)
+
 class JobRun(Base):
     __tablename__ = "job_runs"
     id = Column(Integer, primary_key=True, autoincrement=True)

--- a/tests/test_captura_endpoints.py
+++ b/tests/test_captura_endpoints.py
@@ -4,7 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from sirep.app.api import app
-from sirep.domain.models import DiscardedPlan, Plan
+from sirep.domain.models import CaptureEvent, DiscardedPlan, Plan
 from sirep.infra.db import SessionLocal, init_db
 
 
@@ -14,6 +14,7 @@ def client_with_data():
     with SessionLocal() as db:
         db.query(DiscardedPlan).delete()
         db.query(Plan).delete()
+        db.query(CaptureEvent).delete()
         db.commit()
 
         plan = Plan(

--- a/tests/test_captura_historico.py
+++ b/tests/test_captura_historico.py
@@ -1,0 +1,39 @@
+from sirep.app.captura import CapturaService
+from sirep.domain.models import CaptureEvent
+from sirep.infra.db import SessionLocal, init_db
+
+
+def _limpar_historico():
+    with SessionLocal() as db:
+        db.query(CaptureEvent).delete()
+        db.commit()
+
+
+def test_historico_persiste_entre_instancias():
+    init_db()
+    _limpar_historico()
+
+    service = CapturaService()
+    service._history_limit = 5
+
+    for idx in range(7):
+        service._registrar_historico(
+            numero_plano=f"PLN-{idx}",
+            progresso=idx % 5,
+            etapa=f"Etapa {idx % 4}",
+            mensagem=f"Evento {idx}",
+        )
+
+    # Garante que o próprio serviço respeita o limite em memória
+    historico_atual = service.status().historico
+    assert len(historico_atual) == 5
+    assert [item.mensagem for item in historico_atual] == [f"Evento {i}" for i in range(2, 7)]
+
+    # Simula reinício da aplicação criando uma nova instância
+    novo_service = CapturaService()
+    novo_service._history_limit = 5
+
+    status = novo_service.status()
+    assert len(status.historico) == 5
+    assert [item.mensagem for item in status.historico] == [f"Evento {i}" for i in range(2, 7)]
+    assert status.ultima_atualizacao == status.historico[-1].timestamp


### PR DESCRIPTION
## Summary
- add the CaptureEvent table to persist capture history events with the required UI fields
- expose a repository to insert and query capture history, wiring CapturaService to load and persist events while keeping the in-memory cache
- cover persistence behaviour with a regression test and reset the database fixtures to clear capture events

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cea54bbffc8323b88a5fba1d9a7b20