### PR TITLE
Ajusta exibição de horário para fuso de Brasília

### DIFF
--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -142,6 +142,14 @@
 <script>
 function $(selector){ return document.querySelector(selector); }
 const fmtMoney=n=>n==null?"":Number(n).toLocaleString("pt-BR",{style:"currency",currency:"BRL"});
+const TIMEZONE="America/Sao_Paulo";
+function formatDateTime(value,options){
+  if(!value)return"";
+  const date=new Date(value);
+  if(Number.isNaN(date.getTime()))return"";
+  const opts={timeZone:TIMEZONE,...(options||{})};
+  return date.toLocaleString("pt-BR",opts);
+}
 const el={
   btnIniciar:$("#btnIniciar"), btnPausar:$("#btnPausar"), btnContinuar:$("#btnContinuar"),
   barTotal:$("#barTotal"), lblTotal:$("#lblTotal"), ultima:$("#ultimaAtualizacao"),
@@ -249,10 +257,9 @@ async function carregarOcorrencias(){
 }
 
 function formatLogMessage(item){
-  const dataHora=item.timestamp?
-    new Date(item.timestamp).toLocaleString("pt-BR",{
-      day:"2-digit",month:"2-digit",year:"numeric",hour:"2-digit",minute:"2-digit"
-    }):"";
+  const dataHora=formatDateTime(item.timestamp,{
+    day:"2-digit",month:"2-digit",year:"numeric",hour:"2-digit",minute:"2-digit"
+  });
   const numero=(item.numero_plano||"").trim();
   const mensagem=(item.mensagem||"").trim();
   let corpo="";
@@ -298,7 +305,8 @@ async function carregarStatus(){
   const s=await api("/captura/status");
   stateButtons(s.estado); setBar(s.progresso_total);
   renderLog(s.em_progresso||[], s.historico||[]);
-  el.ultima.textContent="Última atualização: "+(s.ultima_atualizacao?new Date(s.ultima_atualizacao).toLocaleString("pt-BR"):"—");
+  const ultimaAtualizacao=formatDateTime(s.ultima_atualizacao);
+  el.ultima.textContent="Última atualização: "+(ultimaAtualizacao||"—");
   el.badgeOcorr.textContent = s.ocorrencias_total ?? 0;
 }
 


### PR DESCRIPTION
## Summary
- garante que os horários exibidos na interface sejam convertidos para o fuso America/Sao_Paulo
- centraliza a formatação de data/hora para reutilização no histórico e na última atualização

## Testing
- PYTHONPATH=$PWD pytest

------
https://chatgpt.com/codex/tasks/task_e_68cea96f9a188323a2f1c579348412da