### PR TITLE
Adjust events panel height to match main card

### DIFF
--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -28,8 +28,9 @@
     .progress>div{height:100%;background:linear-gradient(90deg,var(--prog-a),var(--prog-b));position:relative;transition:width .2s ease}
     table{width:100%;border-collapse:collapse} th,td{padding:10px;border-bottom:1px solid var(--line)}
     th{text-align:left;font-size:12px;color:#4b5563} .right{text-align:right}
-    .grid{display:grid;grid-template-columns:1fr 320px;gap:16px} @media (max-width:980px){.grid{grid-template-columns:1fr}}
-    .log{border:1px solid var(--line);border-radius:10px;padding:10px;height:320px;overflow:auto;background:#fafafa}
+    .grid{display:grid;grid-template-columns:minmax(0,1fr) 320px;gap:16px;align-items:stretch} @media (max-width:980px){.grid{grid-template-columns:1fr}}
+    .grid>aside{display:flex;flex-direction:column}
+    .log{border:1px solid var(--line);border-radius:10px;padding:10px;overflow:auto;background:#fafafa;flex:1 1 auto;min-height:0}
     .log p{margin:0 0 6px}
     .log .log-active{font-weight:600}
     .log .log-history{color:var(--muted);font-size:12px}


### PR DESCRIPTION
## Summary
- stretch the events log column to follow the height of the main card using CSS grid and flex layout
- remove the fixed height on the events log so it expands dynamically with the main content

## Testing
- pytest *(fails: missing httpx and sirep modules in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceab6d56888323bd5fb404dbf13e17