### PR TITLE
Adjust log panel height to reach card bottom

### DIFF
--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -177,8 +177,10 @@ function syncLogHeight(){
   const offsetTop=logElement.offsetTop+(parseFloat(logStyle.marginTop)||0);
   const bottomSpacing=(parseFloat(logStyle.marginBottom)||0)+(parseFloat(asideStyle.paddingBottom)||0);
   const available=Math.max(0,mainRect.height-offsetTop-bottomSpacing);
-  logElement.style.maxHeight=`${available}px`;
-  logElement.style.height="";
+  const size=`${available}px`;
+  logElement.style.maxHeight=size;
+  logElement.style.minHeight=size;
+  logElement.style.height=size;
 }
 function scheduleLogSync(){
   if(logHeightFrame!==null) return;


### PR DESCRIPTION
## Summary
- lock the event log panel height to the calculated available space
- ensure the event window extends to the bottom of the Gestão da Base card

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ceb0e256c4832385921521ce40c950