### PR TITLE
Add completion modal for captura conclued

### DIFF
--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -48,6 +48,12 @@
     .copy.copied::before{content:"";position:absolute;left:50%;top:-10px;transform:translateX(-50%);border:6px solid transparent;border-top-color:rgba(17,17,17,.92);pointer-events:none;animation:copy-tooltip-arrow .9s ease;z-index:19}
     @keyframes copy-tooltip{0%{opacity:0;transform:translate(-50%,-4px)}20%{opacity:1;transform:translate(-50%,-10px)}80%{opacity:1;transform:translate(-50%,-12px)}100%{opacity:0;transform:translate(-50%,-14px)}}
     @keyframes copy-tooltip-arrow{0%{opacity:0;transform:translate(-50%,2px)}20%{opacity:1;transform:translate(-50%,0)}80%{opacity:1;transform:translate(-50%,-1px)}100%{opacity:0;transform:translate(-50%,-2px)}}
+    .modal-backdrop{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(17,24,39,.55);backdrop-filter:blur(2px);z-index:50;padding:16px}
+    .modal-backdrop.active{display:flex}
+    .modal-card{background:#fff;border-radius:16px;max-width:320px;width:100%;padding:28px 22px;box-shadow:0 18px 40px rgba(15,23,42,.25);text-align:center}
+    .modal-card h3{margin:0 0 12px;font-size:18px;font-weight:800;color:var(--accent)}
+    .modal-card p{margin:0 0 24px;color:var(--text)}
+    .modal-card button{min-width:88px}
   </style>
 </head>
 <body>
@@ -140,6 +146,14 @@
   </div>
 </main>
 
+<div class="modal-backdrop" id="modalConcluido" role="dialog" aria-modal="true" aria-labelledby="modalConcluidoTitulo" aria-hidden="true">
+  <div class="modal-card">
+    <h3 id="modalConcluidoTitulo">Processamento concluído!</h3>
+    <p>Os planos foram capturados com sucesso.</p>
+    <button type="button" id="btnModalOk" class="primary">Ok</button>
+  </div>
+</div>
+
 <script>
 function $(selector){ return document.querySelector(selector); }
 const fmtMoney=n=>n==null?"":Number(n).toLocaleString("pt-BR",{style:"currency",currency:"BRL"});
@@ -159,7 +173,8 @@ const el={
   tbodyOcc:$("#tbodyOcc"), btnProximoOcc:$("#btnProximoOcc"), btnAnteriorOcc:$("#btnAnteriorOcc"),
   lblPaginaTotalOcc:$("#lblPaginaTotalOcc"), footerInfoOcc:$("#footerInfoOcc"),
   log:$("#log"), estadoTexto:$("#estadoTexto"),
-  subtabPlanos:$("#subtabPlanos"), subtabOcorr:$("#subtabOcorr"), badgeOcorr:$("#badgeOcorr")
+  subtabPlanos:$("#subtabPlanos"), subtabOcorr:$("#subtabOcorr"), badgeOcorr:$("#badgeOcorr"),
+  modalConcluido:$("#modalConcluido"), btnModalOk:$("#btnModalOk")
 };
 const mainColumn=document.querySelector(".grid > div");
 const asideColumn=document.querySelector(".grid > aside");
@@ -199,6 +214,22 @@ window.addEventListener("resize",scheduleLogSync);
 let pagina=1,tamanho=10,totalPlanos={all:0,passiveis:0},maxPaginas=1;
 let paginaOcc=1,totalOcc=0,maxPaginasOcc=1;
 let timer=null;
+let ultimoEstado=null;
+
+function abrirModalConclusao(){
+  if(!el.modalConcluido) return;
+  el.modalConcluido.classList.add("active");
+  el.modalConcluido.setAttribute("aria-hidden","false");
+  if(el.btnModalOk){
+    try{el.btnModalOk.focus();}catch(_e){}
+  }
+}
+
+function fecharModalConclusao(){
+  if(!el.modalConcluido) return;
+  el.modalConcluido.classList.remove("active");
+  el.modalConcluido.setAttribute("aria-hidden","true");
+}
 
 function setBar(p){el.barTotal.style.width=`${p}%`;el.lblTotal.textContent=`${p}% concluído`}
 function stateButtons(estado){
@@ -342,11 +373,16 @@ function renderLog(_emProgresso, historico){
 
 async function carregarStatus(){
   const s=await api("/captura/status");
-  stateButtons(s.estado); setBar(s.progresso_total);
+  const estadoAtual=s.estado;
+  stateButtons(estadoAtual); setBar(s.progresso_total);
   renderLog(s.em_progresso||[], s.historico||[]);
   const ultimaAtualizacao=formatDateTime(s.ultima_atualizacao);
   el.ultima.textContent="Última atualização: "+(ultimaAtualizacao||"—");
   el.badgeOcorr.textContent = s.ocorrencias_total ?? 0;
+  if(ultimoEstado && ultimoEstado!=="concluido" && estadoAtual==="concluido"){
+    abrirModalConclusao();
+  }
+  ultimoEstado=estadoAtual;
 }
 
 function startPolling(){
@@ -368,6 +404,12 @@ el.btnAnteriorOcc.onclick=()=>{if(paginaOcc>1){paginaOcc-=1;carregarOcorrencias(
 
 el.subtabPlanos.onclick=()=>{el.subtabPlanos.classList.add("active");el.subtabOcorr.classList.remove("active");$("#wrapPlanos").style.display="block";$("#wrapOcorr").style.display="none";scheduleLogSync();};
 el.subtabOcorr.onclick=()=>{el.subtabOcorr.classList.add("active");el.subtabPlanos.classList.remove("active");$("#wrapPlanos").style.display="none";$("#wrapOcorr").style.display="block";carregarOcorrencias();scheduleLogSync();};
+
+if(el.btnModalOk){
+  el.btnModalOk.addEventListener("click",()=>{
+    fecharModalConclusao();
+  });
+}
 
 document.addEventListener("DOMContentLoaded", async()=>{await carregarStatus();await carregarPlanos();startPolling();scheduleLogSync();});
 </script>


### PR DESCRIPTION
## Summary
- add a modal overlay to inform users when a captura run finishes
- trigger the modal once the status transitions to `concluido` and allow dismissing it with an OK button

## Testing
- `pytest` *(fails: missing optional dependencies `httpx`, import path for `sirep`)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb8ab53ac8323bdc7ff1699939e70