### PR TITLE
Ajusta janela de eventos e remove sombra dos botões

### DIFF
--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -20,8 +20,8 @@
     .content{padding:16px}
     .controls{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
     button{appearance:none;border:1px solid var(--line);background:#fff;color:var(--text);padding:9px 14px;border-radius:10px;cursor:pointer;font-weight:700}
-    button.primary{border:0;color:#fff;background:linear-gradient(90deg,var(--hdr-b),var(--hdr-c));box-shadow:0 6px 16px rgba(16,140,188,.22);transition:transform .15s ease,box-shadow .15s ease}
-    button.primary:hover:not(:disabled){transform:translateY(-1px);box-shadow:0 10px 20px rgba(16,140,188,.28)}
+    button.primary{border:0;color:#fff;background:linear-gradient(90deg,var(--hdr-b),var(--hdr-c));box-shadow:none;transition:transform .15s ease}
+    button.primary:hover:not(:disabled){transform:translateY(-1px)}
     button:disabled{opacity:.5;cursor:not-allowed}
     .muted{color:var(--muted);font-size:12px}
     .row{display:flex;gap:14px;flex-wrap:wrap;align-items:center}
@@ -29,9 +29,9 @@
     .progress>div{height:100%;background:linear-gradient(90deg,var(--prog-a),var(--prog-b));position:relative;transition:width .2s ease}
     table{width:100%;border-collapse:collapse} th,td{padding:10px;border-bottom:1px solid var(--line)}
     th{text-align:left;font-size:12px;color:#4b5563} .right{text-align:right}
-    .grid{display:grid;grid-template-columns:minmax(0,1fr) 320px;gap:16px;align-items:stretch} @media (max-width:980px){.grid{grid-template-columns:1fr}}
+    .grid{display:grid;grid-template-columns:minmax(0,1fr) clamp(320px,28vw,420px);gap:16px;align-items:stretch} @media (max-width:980px){.grid{grid-template-columns:1fr}}
     .grid>aside{display:flex;flex-direction:column;min-height:0}
-    .log{border:1px solid var(--line);border-radius:10px;padding:10px;overflow:auto;background:#fafafa;flex:1 1 auto;min-height:0}
+    .log{border:1px solid var(--line);border-radius:10px;padding:10px;overflow:auto;background:#fafafa;flex:1 1 auto;min-height:280px}
     .log p{margin:0 0 6px}
     .log .log-active{font-weight:600}
     .log .log-history{color:var(--muted);font-size:12px}
@@ -183,6 +183,7 @@ const logElement=el.log;
 const requestFrame=(typeof window!=="undefined"&&typeof window.requestAnimationFrame==="function")
   ? window.requestAnimationFrame.bind(window)
   : (fn)=>setTimeout(fn,16);
+const MIN_LOG_HEIGHT=280;
 let logHeightFrame=null;
 function resetLogSizing(){
   if(logElement){
@@ -192,6 +193,9 @@ function resetLogSizing(){
   }
   if(asideColumn){
     asideColumn.style.removeProperty("height");
+  }
+  if(mainColumn){
+    mainColumn.style.removeProperty("minHeight");
   }
 }
 function syncLogHeight(){
@@ -214,13 +218,25 @@ function syncLogHeight(){
   const logStyle=getComputedStyle(logElement);
   const logRect=logElement.getBoundingClientRect();
   const relativeTop=logRect.top-asideRect.top;
-  const bottomSpacing=(parseFloat(logStyle.marginBottom)||0)+(parseFloat(asideStyle.paddingBottom)||0)+(parseFloat(asideStyle.borderBottomWidth)||0);
+  const logMarginBottom=parseFloat(logStyle.marginBottom)||0;
+  const bottomSpacing=logMarginBottom+(parseFloat(asideStyle.paddingBottom)||0)+(parseFloat(asideStyle.borderBottomWidth)||0);
   const available=Math.max(0,mainRect.height-relativeTop-bottomSpacing);
-  const size=`${available}px`;
+  const viewportAllowance=(typeof window!=="undefined")
+    ? Math.max(0,window.innerHeight-logRect.top-logMarginBottom-24)
+    : 0;
+  const viewportCap=(typeof window!=="undefined")
+    ? Math.max(MIN_LOG_HEIGHT,window.innerHeight-160)
+    : MIN_LOG_HEIGHT;
+  const baseHeight=Math.max(MIN_LOG_HEIGHT,available,viewportAllowance);
+  const targetHeight=Math.min(Math.max(baseHeight,MIN_LOG_HEIGHT),viewportCap);
+  const asideHeight=targetHeight+relativeTop+bottomSpacing;
+  const finalAsideHeight=Math.max(mainRect.height,asideHeight);
+  const size=`${targetHeight}px`;
   logElement.style.maxHeight=size;
   logElement.style.minHeight=size;
   logElement.style.height=size;
-  asideColumn.style.height=`${mainRect.height}px`;
+  asideColumn.style.height=`${finalAsideHeight}px`;
+  mainColumn.style.minHeight=`${finalAsideHeight}px`;
 }
 function scheduleLogSync(){
   if(logHeightFrame!==null) return;


### PR DESCRIPTION
## Resumo
- remove a sombra aplicada aos botões primários para seguir o novo padrão visual
- aumenta a largura da coluna de eventos e força a área de log a ocupar uma altura mínima confortável, respeitando também o espaço disponível na janela
- garante que a altura do cartão principal acompanhe o ajuste para evitar cortes ao alternar entre disposições

## Testes
- [x] Teste manual da interface web

------
https://chatgpt.com/codex/tasks/task_e_68cec09c7eac8323a95e304fd4a038dd