### PR TITLE
Adjust primary action button styling

### DIFF
--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -20,8 +20,10 @@
     .content{padding:16px}
     .controls{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
     button{appearance:none;border:1px solid var(--line);background:#fff;color:var(--text);padding:9px 14px;border-radius:10px;cursor:pointer;font-weight:700}
-    button.primary{border:0;color:#fff;background:linear-gradient(90deg,var(--hdr-b),var(--hdr-c));box-shadow:none;transition:transform .15s ease}
-    button.primary:hover:not(:disabled){transform:translateY(-1px)}
+    #btnIniciar,#btnContinuar{padding:12px 26px;font-size:15px;border-radius:12px}
+    button.primary{border:0;color:#fff;background:#108CBC;box-shadow:none;transition:transform .15s ease,background-color .15s ease}
+    button.primary:hover:not(:disabled){background:#0b749f;transform:translateY(-1px)}
+    #btnContinuar:not(.primary){background:#f3f4f6;color:var(--muted);border-color:#d1d5db}
     button:disabled{opacity:.5;cursor:not-allowed}
     .muted{color:var(--muted);font-size:12px}
     .row{display:flex;gap:14px;flex-wrap:wrap;align-items:center}


### PR DESCRIPTION
## Summary
- enlarge the Iniciar and Continuar buttons for better emphasis
- apply the solid #108CBC styling to active primary buttons while keeping Continuar muted when disabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cec6eab2f08323814b82e3694e40e1