### PR TITLE
Ensure capture history timestamps are timezone aware

### DIFF
--- a/sirep/app/captura.py
+++ b/sirep/app/captura.py
@@ -299,7 +299,10 @@ class CapturaService:
 
         historico: List[PlanoHistorico] = []
         for ev in reversed(eventos):
-            ts = ev.timestamp.isoformat() if ev.timestamp else None
+            timestamp_dt = ev.timestamp
+            if timestamp_dt and timestamp_dt.tzinfo is None:
+                timestamp_dt = timestamp_dt.replace(tzinfo=timezone.utc)
+            ts = timestamp_dt.isoformat() if timestamp_dt else None
             historico.append(
                 PlanoHistorico(
                     numero_plano=ev.numero_plano,

--- a/tests/test_captura_historico.py
+++ b/tests/test_captura_historico.py
@@ -37,3 +37,24 @@ def test_historico_persiste_entre_instancias():
     assert len(status.historico) == 5
     assert [item.mensagem for item in status.historico] == [f"Evento {i}" for i in range(2, 7)]
     assert status.ultima_atualizacao == status.historico[-1].timestamp
+
+
+def test_historico_carregado_mantem_fuso_horario():
+    init_db()
+    _limpar_historico()
+
+    service = CapturaService()
+    service._registrar_historico(
+        numero_plano="PLN-001",
+        progresso=1,
+        etapa="Etapa 1",
+        mensagem="Evento com fuso",
+    )
+
+    novo_service = CapturaService()
+    status = novo_service.status()
+
+    assert status.historico, "Histórico deveria conter ao menos um evento"
+    timestamp = status.historico[-1].timestamp
+    assert timestamp.endswith("+00:00")
+    assert status.ultima_atualizacao.endswith("+00:00")


### PR DESCRIPTION
## Summary
- normalize persisted capture event timestamps to ensure timezone information is kept when loading history
- add a regression test covering timezone-aware timestamps when reinitializing the capture service

## Testing
- PYTHONPATH=/workspace/auto_res pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf2b6afea48323be4ddf002e494aa4