### PR TITLE
Fix log panel sizing after session restart

### DIFF
--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -279,6 +279,12 @@ function syncLogHeight(){
     resetLogSizing();
     return;
   }
+  // clear previous inline sizing so measurements reflect the current layout
+  logElement.style.removeProperty("maxHeight");
+  logElement.style.removeProperty("minHeight");
+  logElement.style.removeProperty("height");
+  asideColumn.style.removeProperty("height");
+  mainColumn.style.removeProperty("minHeight");
   const isStacked=typeof window!=="undefined"&&typeof window.matchMedia==="function"&&window.matchMedia("(max-width: 980px)").matches;
   if(isStacked){
     resetLogSizing();


### PR DESCRIPTION
## Summary
- clear previous inline log sizing before recalculating the sidebar log height so the panel stays within the defined bounds after a new session starts

## Testing
- not run (front-end only change)


------
https://chatgpt.com/codex/tasks/task_e_68cf4cb202f08323ba76dbf3fdb928c4