### PR TITLE
Allow event log to fill column height

### DIFF
--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -307,26 +307,13 @@ function syncLogHeight(){
     resetLogSizing();
     return;
   }
-  const viewportAllowance=(typeof window!=="undefined")
-    ? Math.max(0,window.innerHeight-logRect.top-logMarginBottom-24)
-    : 0;
-  const viewportCap=(typeof window!=="undefined")
-    ? Math.max(MIN_LOG_HEIGHT,window.innerHeight-160)
-    : MIN_LOG_HEIGHT;
   const minHeight=Math.min(MIN_LOG_HEIGHT,available);
-  let targetHeight=available;
-  if(viewportAllowance>0){
-    const allowanceLimit=Math.max(minHeight,Math.min(viewportAllowance,available));
-    targetHeight=Math.min(targetHeight,allowanceLimit);
-  }
-  const capLimit=Math.max(minHeight,Math.min(viewportCap,available));
-  targetHeight=Math.min(targetHeight,capLimit);
-  targetHeight=Math.max(minHeight,Math.min(targetHeight,available));
+  const targetHeight=Math.max(minHeight,Math.min(available,mainRect.height));
   const asideHeight=targetHeight+relativeTop+bottomSpacing;
   const finalAsideHeight=Math.max(mainRect.height,asideHeight);
   const size=`${targetHeight}px`;
   logElement.style.maxHeight=size;
-  logElement.style.minHeight=size;
+  logElement.style.minHeight=`${minHeight}px`;
   logElement.style.height=size;
   asideColumn.style.height=`${finalAsideHeight}px`;
   mainColumn.style.minHeight=`${finalAsideHeight}px`;


### PR DESCRIPTION
## Summary
- let the event log height follow the column's available space instead of clamping to viewport allowances
- keep the minimum-height guard while syncing the aside column to the main column

## Testing
- PYTHONPATH=/workspace/auto_res pytest
- Manually verified log height persistence in the browser

------
https://chatgpt.com/codex/tasks/task_e_68cf55e6f9208323bb270905cccb1432