### PR TITLE
Limit log height with viewport cap

### DIFF
--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -316,7 +316,17 @@ function syncLogHeight(){
     return;
   }
   const minHeight=Math.min(MIN_LOG_HEIGHT,available);
-  const targetHeight=Math.max(minHeight,Math.min(available,mainRect.height));
+  let viewportCap=null;
+  if(typeof window!=="undefined"&&typeof window.innerHeight==="number"){
+    const viewportAvailable=window.innerHeight-logRect.top-bottomSpacing;
+    if(Number.isFinite(viewportAvailable)){
+      viewportCap=Math.max(minHeight,Math.max(0,viewportAvailable));
+    }
+  }
+  let targetHeight=Math.max(minHeight,Math.min(available,mainRect.height));
+  if(viewportCap!==null){
+    targetHeight=Math.min(targetHeight,viewportCap);
+  }
   const asideHeight=targetHeight+relativeTop+bottomSpacing;
   const finalAsideHeight=Math.max(mainRect.height,asideHeight);
   const size=`${targetHeight}px`;


### PR DESCRIPTION
## Summary
- add a viewport-based cap when calculating the log panel height
- keep existing min/max height styling while preventing the log card from exceeding the screen height

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cf5b51e3d88323b250f10f1aa60a89