### PR TITLE
Refine capture completion modal

### DIFF
--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -72,10 +72,22 @@
     @keyframes copy-tooltip-arrow{0%{opacity:0;transform:translate(-50%,2px)}20%{opacity:1;transform:translate(-50%,0)}80%{opacity:1;transform:translate(-50%,-1px)}100%{opacity:0;transform:translate(-50%,-2px)}}
     .modal-backdrop{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(17,24,39,.55);backdrop-filter:blur(2px);z-index:50;padding:16px}
     .modal-backdrop.active{display:flex}
-    .modal-card{background:#fff;border-radius:16px;max-width:320px;width:100%;padding:28px 22px;box-shadow:0 18px 40px rgba(15,23,42,.25);text-align:center}
-    .modal-card h3{margin:0 0 12px;font-size:18px;font-weight:800;color:var(--accent)}
-    .modal-card p{margin:0 0 24px;color:var(--text)}
-    .modal-card button{min-width:88px}
+    .modal-card{background:#f8fafc;border-radius:18px;max-width:360px;width:100%;box-shadow:0 20px 48px rgba(15,23,42,.28);border:1px solid rgba(15,23,42,.14);overflow:hidden;padding:0;text-align:left}
+    .modal-card[role="document"]{outline:none}
+    .modal-titlebar{display:flex;align-items:center;gap:10px;background:linear-gradient(135deg,#0b5fa8,#108cbc);color:#fff;padding:16px 20px;border-bottom:1px solid rgba(255,255,255,.35)}
+    .modal-titlebar h3{margin:0;font-size:16px;font-weight:800;letter-spacing:.3px}
+    .modal-title-icon{width:28px;height:28px;border-radius:8px;background:rgba(255,255,255,.18);display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;color:#fff}
+    .modal-title-icon svg{width:18px;height:18px;stroke:#fff;stroke-width:2.2}
+    .modal-close{margin-left:auto;border:0;background:rgba(255,255,255,.16);color:#fff;width:28px;height:28px;border-radius:6px;font-size:16px;font-weight:700;line-height:1;display:inline-flex;align-items:center;justify-content:center;cursor:pointer;transition:background-color .15s ease,transform .15s ease}
+    .modal-close:hover,.modal-close:focus-visible{background:rgba(255,255,255,.28);outline:none;transform:translateY(-1px)}
+    .modal-body{padding:24px 24px 18px;display:flex;gap:16px;align-items:flex-start;background:#fff}
+    .modal-illustration{width:52px;height:52px;border-radius:14px;background:linear-gradient(135deg,rgba(15,95,168,.12),rgba(16,140,188,.25));display:inline-flex;align-items:center;justify-content:center;color:var(--accent);flex-shrink:0;border:1px solid rgba(16,140,188,.2);box-shadow:inset 0 0 0 1px rgba(255,255,255,.4)}
+    .modal-illustration svg{width:26px;height:26px;stroke:currentColor;stroke-width:2.2}
+    .modal-copy{flex:1 1 auto;color:var(--text)}
+    .modal-message{margin:0 0 8px;font-size:17px;font-weight:800;color:#0f172a}
+    .modal-detail{margin:0;color:#475569;font-size:13px;line-height:1.6}
+    .modal-actions{display:flex;justify-content:flex-end;gap:10px;padding:18px 24px 22px;background:linear-gradient(180deg,#f8fafc 0%,#eef2f7 100%);border-top:1px solid rgba(15,23,42,.08)}
+    .modal-card button{min-width:96px}
   </style>
 </head>
 <body>
@@ -198,10 +210,26 @@
 </main>
 
 <div class="modal-backdrop" id="modalConcluido" role="dialog" aria-modal="true" aria-labelledby="modalConcluidoTitulo" aria-hidden="true">
-  <div class="modal-card">
-    <h3 id="modalConcluidoTitulo">Processamento concluído!</h3>
-    <p>Os planos foram capturados com sucesso.</p>
-    <button type="button" id="btnModalOk" class="primary">Ok</button>
+  <div class="modal-card" role="document" tabindex="-1">
+    <div class="modal-titlebar">
+      <span class="modal-title-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none"><path d="m6 12 4 4 8-8" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </span>
+      <h3 id="modalConcluidoTitulo">Processamento concluído</h3>
+      <button type="button" id="btnModalClose" class="modal-close" aria-label="Fechar aviso">×</button>
+    </div>
+    <div class="modal-body">
+      <div class="modal-illustration" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none"><path d="M12 3c4.97 0 9 4.03 9 9s-4.03 9-9 9-9-4.03-9-9 4.03-9 9-9Z" stroke="currentColor" stroke-width="1.6"/><path d="m9.5 12 1.95 1.95 4.05-4.05" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </div>
+      <div class="modal-copy">
+        <p class="modal-message">Captura finalizada com sucesso.</p>
+        <p class="modal-detail">Os planos foram processados sem pendências e esta janela segue um visual clássico para destacar o fim da captura.</p>
+      </div>
+    </div>
+    <div class="modal-actions">
+      <button type="button" id="btnModalOk" class="primary">Ok</button>
+    </div>
   </div>
 </div>
 
@@ -259,7 +287,7 @@ const el={
   filtroOcorrTrigger:$("#filtroOcorrTrigger"),
   log:$("#log"), estadoTexto:$("#estadoTexto"),
   subtabPlanos:$("#subtabPlanos"), subtabOcorr:$("#subtabOcorr"), badgeOcorr:$("#badgeOcorr"),
-  modalConcluido:$("#modalConcluido"), btnModalOk:$("#btnModalOk")
+  modalConcluido:$("#modalConcluido"), btnModalOk:$("#btnModalOk"), btnModalClose:$("#btnModalClose")
 };
 const mainColumn=document.querySelector(".grid > div");
 const asideColumn=document.querySelector(".grid > aside");
@@ -373,7 +401,11 @@ function abrirModalConclusao(){
   el.modalConcluido.classList.add("active");
   el.modalConcluido.setAttribute("aria-hidden","false");
   if(el.btnModalOk){
-    try{el.btnModalOk.focus();}catch(_e){}
+    try{el.btnModalOk.focus();return;}catch(_e){}
+  }
+  const card=el.modalConcluido?el.modalConcluido.querySelector(".modal-card"):null;
+  if(card){
+    try{card.focus();}catch(_e){}
   }
 }
 
@@ -741,6 +773,18 @@ if(el.btnModalOk){
     fecharModalConclusao();
   });
 }
+
+if(el.btnModalClose){
+  el.btnModalClose.addEventListener("click",()=>{
+    fecharModalConclusao();
+  });
+}
+
+document.addEventListener("keydown",event=>{
+  if(event.key==="Escape"&&el.modalConcluido&&el.modalConcluido.classList.contains("active")){
+    fecharModalConclusao();
+  }
+});
 
 document.addEventListener("DOMContentLoaded", async()=>{await carregarStatus();await carregarPlanos();startPolling();scheduleLogSync();});
 </script>


### PR DESCRIPTION
## Summary
- redesenha o popup de conclusão da captura com cabeçalho clássico, ícone e copy revisada
- adiciona botão de fechar, suporte à tecla Escape e melhorias de foco no modal

## Testing
- PYTHONPATH=$PWD pytest

## Screenshots
![Popup clássico da captura](browser:/invocations/vvzbopcy/artifacts/artifacts/popup-classico.png)

------
https://chatgpt.com/codex/tasks/task_e_68cff02f46308323b5e7db639dab9eb1