### PR TITLE
Adjust log height helper to match table column

### DIFF
--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -339,6 +339,16 @@ function getMainIntrinsicHeight(mainRect){
   }else if(intrinsicHeight<minHeight){
     intrinsicHeight=minHeight;
   }
+  const scrollHeight=mainColumn.scrollHeight;
+  if(Number.isFinite(scrollHeight)&&scrollHeight>0){
+    const scrollBasedHeight=scrollHeight+borderTop+borderBottom;
+    if(scrollBasedHeight>intrinsicHeight){
+      intrinsicHeight=scrollBasedHeight;
+    }
+  }
+  if(mainRect&&Number.isFinite(mainRect.height)&&mainRect.height>intrinsicHeight){
+    intrinsicHeight=mainRect.height;
+  }
   if(!Number.isFinite(intrinsicHeight)||intrinsicHeight<=0){
     return mainRect&&Number.isFinite(mainRect.height)?mainRect.height:0;
   }


### PR DESCRIPTION
## Summary
- garante que o helper de cálculo de altura considere a altura real renderizada da coluna principal
- utiliza scrollHeight e o valor atual do layout como fallback para manter a janela de eventos alinhada com a tabela

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0052d273c83239fe7cf393451b8b2