### PR TITLE
Ajusta layout e scroll do painel de eventos

### DIFF
--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -284,6 +284,7 @@ const requestFrame=(typeof window!=="undefined"&&typeof window.requestAnimationF
   : (fn)=>setTimeout(fn,16);
 const MIN_LOG_HEIGHT=280;
 let logHeightFrame=null;
+let shouldAutoScrollLog=true;
 function resetLogSizing(){
   if(logElement){
     logElement.style.removeProperty("maxHeight");
@@ -309,50 +310,22 @@ function getMainIntrinsicHeight(mainRect){
   }catch(_e){
     return mainRect&&Number.isFinite(mainRect.height)?mainRect.height:0;
   }
-  const paddingTop=parseFloat(columnStyle.paddingTop)||0;
-  const paddingBottom=parseFloat(columnStyle.paddingBottom)||0;
   const borderTop=parseFloat(columnStyle.borderTopWidth)||0;
   const borderBottom=parseFloat(columnStyle.borderBottomWidth)||0;
-  let maxBottom=0;
-  Array.from(mainColumn.children||[]).forEach((child)=>{
-    if(!(child instanceof HTMLElement)) return;
-    let childStyle;
-    try{
-      childStyle=getComputedStyle(child);
-    }catch(_err){
-      return;
-    }
-    if(childStyle.display==="none"||childStyle.visibility==="hidden"||childStyle.visibility==="collapse") return;
-    if(child.offsetParent===null&&childStyle.position!=="fixed") return;
-    const childHeight=child.offsetHeight;
-    if(childHeight<=0) return;
-    const childTop=child.offsetTop;
-    if(!Number.isFinite(childTop)||!Number.isFinite(childHeight)) return;
-    const bottom=childTop+childHeight;
-    if(bottom>maxBottom) maxBottom=bottom;
-  });
-  const paddingTotal=paddingTop+paddingBottom;
-  const minHeight=paddingTotal+borderTop+borderBottom;
-  let intrinsicHeight=maxBottom+paddingBottom+borderTop+borderBottom;
-  if(maxBottom<=0){
-    intrinsicHeight=minHeight;
-  }else if(intrinsicHeight<minHeight){
-    intrinsicHeight=minHeight;
+  const paddingTop=parseFloat(columnStyle.paddingTop)||0;
+  const paddingBottom=parseFloat(columnStyle.paddingBottom)||0;
+  const verticalExtras=borderTop+borderBottom+paddingTop+paddingBottom;
+  const scrollHeight=Number.isFinite(mainColumn.scrollHeight)
+    ? mainColumn.scrollHeight+borderTop+borderBottom
+    : 0;
+  const offsetHeight=Number.isFinite(mainColumn.offsetHeight)?mainColumn.offsetHeight:0;
+  const rectHeight=mainRect&&Number.isFinite(mainRect.height)?mainRect.height:0;
+  const candidates=[scrollHeight,offsetHeight,rectHeight,verticalExtras]
+    .filter(value=>Number.isFinite(value)&&value>0);
+  if(candidates.length===0){
+    return 0;
   }
-  const scrollHeight=mainColumn.scrollHeight;
-  if(Number.isFinite(scrollHeight)&&scrollHeight>0){
-    const scrollBasedHeight=scrollHeight+borderTop+borderBottom;
-    if(scrollBasedHeight>intrinsicHeight){
-      intrinsicHeight=scrollBasedHeight;
-    }
-  }
-  if(mainRect&&Number.isFinite(mainRect.height)&&mainRect.height>intrinsicHeight){
-    intrinsicHeight=mainRect.height;
-  }
-  if(!Number.isFinite(intrinsicHeight)||intrinsicHeight<=0){
-    return mainRect&&Number.isFinite(mainRect.height)?mainRect.height:0;
-  }
-  return intrinsicHeight;
+  return Math.max(...candidates);
 }
 function syncLogHeight(){
   if(!mainColumn||!asideColumn||!logElement){
@@ -390,32 +363,17 @@ function syncLogHeight(){
     resetLogSizing();
     return;
   }
-  const preferredHeight=Math.max(MIN_LOG_HEIGHT,available);
-  let viewportCap=null;
-  if(typeof window!=="undefined"&&typeof window.innerHeight==="number"){
-    const viewportAvailable=window.innerHeight-logRect.top-bottomSpacing;
-    if(Number.isFinite(viewportAvailable)){
-      viewportCap=Math.max(0,viewportAvailable);
-    }
-  }
-  const isClamped=viewportCap!==null&&preferredHeight>viewportCap;
-  const targetHeight=isClamped?Math.max(0,viewportCap):preferredHeight;
-  const asideHeight=targetHeight+relativeTop+bottomSpacing;
-  const finalAsideHeight=isClamped?asideHeight:Math.max(mainContentHeight,asideHeight);
+  const targetHeight=Math.max(MIN_LOG_HEIGHT,available);
+  const requiredHeight=relativeTop+targetHeight+bottomSpacing;
+  const finalAsideHeight=Math.max(mainContentHeight,requiredHeight);
   const size=`${targetHeight}px`;
   logElement.style.maxHeight=size;
-  const minHeightForStyle=targetHeight<MIN_LOG_HEIGHT?Math.max(0,targetHeight):MIN_LOG_HEIGHT;
-  logElement.style.minHeight=`${minHeightForStyle}px`;
+  logElement.style.minHeight=size;
   logElement.style.height=size;
   asideColumn.style.height=`${finalAsideHeight}px`;
   mainColumn.style.minHeight=`${finalAsideHeight}px`;
-  if(isClamped){
-    mainColumn.style.maxHeight=`${finalAsideHeight}px`;
-    mainColumn.style.overflow="auto";
-  }else{
-    mainColumn.style.removeProperty("maxHeight");
-    mainColumn.style.removeProperty("overflow");
-  }
+  mainColumn.style.removeProperty("maxHeight");
+  mainColumn.style.removeProperty("overflow");
 }
 function scheduleLogSync(){
   if(logHeightFrame!==null) return;
@@ -734,12 +692,14 @@ function renderLog(_emProgresso, historico){
     frag.appendChild(div);
   });
   container.appendChild(frag);
-  if(nearBottom){
+  const stickToBottom=shouldAutoScrollLog||nearBottom;
+  if(stickToBottom){
     container.scrollTop=container.scrollHeight;
   }else{
     const maxScroll=Math.max(0,container.scrollHeight-container.clientHeight);
     container.scrollTop=Math.min(prevScrollTop,maxScroll);
   }
+  shouldAutoScrollLog=false;
   scheduleLogSync();
 }
 


### PR DESCRIPTION
## Summary
- ajusta o cálculo de sincronização de alturas para manter o card de eventos alinhado à tabela de planos
- garante que o log de eventos inicie no item mais recente ao recarregar a interface

## Testing
- Manual - inspeção da interface web

------
https://chatgpt.com/codex/tasks/task_e_68d006cdfa7883239d94d4bb8caa934a