### PR TITLE
Implement Tratamento workflow and UI

### DIFF
--- a/sirep/app/tratamento.py
+++ b/sirep/app/tratamento.py
@@ -1,0 +1,572 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import string
+import threading
+from datetime import date, datetime, timedelta, timezone
+from typing import List, Optional, Literal
+
+from sirep.domain.enums import PlanStatus
+from sirep.domain.models import TreatmentPlan
+from sirep.infra.db import SessionLocal
+from sirep.infra.repositories import (
+    PlanRepository,
+    TreatmentPlanRepository,
+    TreatmentLogRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+EstadoTratamento = Literal["ocioso", "aguardando", "processando"]
+
+STAGES = [
+    (1, "Etapa 1 – Aproveitamento de Recolhimentos"),
+    (2, "Etapa 2 – Substituição – Confissão x Notificação Fiscal"),
+    (3, "Etapa 3 – Pesquisa de Guias no SFG (PIG)"),
+    (4, "Etapa 4 – Lançamento de Guias no FGE (PIG)"),
+    (5, "Etapa 5 – Situação do Plano"),
+    (6, "Etapa 6 – Rescisão"),
+    (7, "Etapa 7 – Comunicação da Rescisão"),
+]
+
+UF_CODES = ["AC", "AL", "AM", "AP", "BA", "CE", "DF", "ES", "GO", "MA", "MG", "MS", "MT", "PA", "PB", "PE", "PI", "PR", "RJ", "RN", "RO", "RR", "RS", "SC", "SE", "SP", "TO", "BH", "BR"]
+RAZAO_PREFIX = ["INDÚSTRIA", "COMÉRCIO", "SERVIÇOS", "TECNOLOGIA", "GRUPO", "CONSÓRCIO", "ALIMENTOS", "ENGENHARIA"]
+RAZAO_SUFFIX = ["DO BRASIL", "GLOBAL", "NACIONAL", "LTDA", "S.A.", "ME", "EIRELI", "& CIA"]
+TIPOS_PARCELAMENTO = ["PARCELAMENTO ORDINÁRIO", "PARCELAMENTO ESPECIAL", "PARCELAMENTO SIMPLIFICADO"]
+
+
+class TratamentoService:
+    def __init__(self) -> None:
+        self._estado: EstadoTratamento = "ocioso"
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._loop_thread: Optional[threading.Thread] = None
+        self._loop_ready = threading.Event()
+        self._worker_task: Optional[asyncio.Future] = None
+        self._queue: Optional[asyncio.Queue[int]] = None
+        self._queue_shadow: List[int] = []
+        self._current_id: Optional[int] = None
+        self._lock = threading.Lock()
+
+    # ---- infra auxiliar ----
+    @staticmethod
+    async def _call_sync(func) -> None:
+        func()
+
+    def _ensure_loop(self) -> asyncio.AbstractEventLoop:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is not None:
+            self._loop = loop
+            if self._queue is None:
+                self._queue = asyncio.Queue()
+            return loop
+
+        existing = self._loop
+        if existing and existing.is_running():
+            if self._queue is None:
+                self._queue = asyncio.Queue()
+            return existing
+
+        loop = asyncio.new_event_loop()
+        self._loop = loop
+        self._queue = asyncio.Queue()
+        self._loop_ready.clear()
+
+        def runner() -> None:
+            asyncio.set_event_loop(loop)
+            self._loop_ready.set()
+            loop.run_forever()
+
+        self._loop_thread = threading.Thread(target=runner, name="tratamento-loop", daemon=True)
+        self._loop_thread.start()
+        self._loop_ready.wait()
+        return loop
+
+    def _run_on_loop(self, func, *, wait: bool = False, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
+        target = loop or self._loop
+        if target is None:
+            return
+
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+
+        if running is target:
+            func()
+            return
+
+        fut = asyncio.run_coroutine_threadsafe(self._call_sync(func), target)
+        if wait:
+            fut.result()
+
+    # ---- status público ----
+    def estado(self) -> EstadoTratamento:
+        with self._lock:
+            if self._current_id is not None:
+                return "processando"
+            if self._queue_shadow:
+                return "aguardando"
+            return self._estado
+
+    # ---- seed mocks ----
+    def seed_planos(self, quantidade: int = 3) -> List[int]:
+        created_ids: List[int] = []
+        with SessionLocal() as db:
+            plans_repo = PlanRepository(db)
+            treatment_repo = TreatmentPlanRepository(db)
+
+            for _ in range(quantidade):
+                numero = self._gerar_numero_plano(db)
+                razao = self._gerar_razao_social()
+                periodo = self._gerar_periodo()
+                cnpjs = self._gerar_cnpjs()
+                bases = self._gerar_bases()
+                tipo = random.choice(TIPOS_PARCELAMENTO)
+
+                plan = plans_repo.upsert(
+                    numero_plano=numero,
+                    gifug=random.choice(["RJ", "SP", "MG", "BA", "RS"]),
+                    situacao_atual="P. RESC",
+                    situacao_anterior="P. RESC",
+                    dias_em_atraso=random.randint(30, 180),
+                    tipo=random.choice(["ADM", "INS", "JUD", "AI", "AJ"]),
+                    dt_situacao_atual=date.today() - timedelta(days=random.randint(10, 90)),
+                    saldo=float(random.randint(5_000, 60_000)),
+                    status=PlanStatus.PASSIVEL_RESC,
+                )
+                plan.cmb_ajuste = ""
+                plan.justificativa = ""
+                plan.matricula = ""
+                plan.dt_parcela_atraso = None
+                plan.representacao = ""
+                plan.data_rescisao = None
+                plan.data_comunicacao = None
+                plan.metodo_comunicacao = None
+                plan.referencia_comunicacao = None
+
+                notas = {
+                    "PLANO": numero,
+                    "CNPJ_CEI": ", ".join(cnpjs),
+                    "RAZAO_SOCIAL": razao,
+                    "E544_TIPO": tipo,
+                    "E544_PERIODO": periodo,
+                    "E544_CNPJS": "\n".join(cnpjs),
+                    "E398_BASES": "\n".join(bases),
+                }
+
+                etapas = [
+                    {
+                        "id": sid,
+                        "nome": nome,
+                        "status": "pendente",
+                        "iniciado_em": None,
+                        "finalizado_em": None,
+                        "mensagem": "",
+                    }
+                    for sid, nome in STAGES
+                ]
+
+                treatment = TreatmentPlan(
+                    plan_id=plan.id,
+                    numero_plano=numero,
+                    razao_social=razao,
+                    status="pendente",
+                    etapa_atual=0,
+                    periodo=periodo,
+                    cnpjs=cnpjs,
+                    notas=notas,
+                    etapas=etapas,
+                    bases=bases,
+                )
+                treatment_repo.add(treatment)
+                created_ids.append(treatment.id)
+
+            db.commit()
+
+        if created_ids:
+            loop = self._ensure_loop()
+            self._start_worker(loop)
+            for treatment_id in created_ids:
+                self._enqueue(treatment_id, loop=loop)
+        return created_ids
+
+    def _gerar_numero_plano(self, db_session) -> str:
+        plans_repo = PlanRepository(db_session)
+        while True:
+            numero = f"TP{random.randint(100000, 999999)}"
+            if not plans_repo.get_by_numero(numero):
+                return numero
+
+    def _gerar_razao_social(self) -> str:
+        prefix = random.choice(RAZAO_PREFIX)
+        middle = random.choice([
+            "ALFA",
+            "BETA",
+            "OMEGA",
+            "DELTA",
+            "PRIME",
+            "UNIAO",
+            "GERAL",
+            "MASTER",
+        ])
+        suffix = random.choice(RAZAO_SUFFIX)
+        return f"{prefix} {middle} {suffix}"
+
+    def _gerar_periodo(self) -> str:
+        inicio = date.today() - timedelta(days=random.randint(365, 1500))
+        fim = inicio + timedelta(days=random.randint(90, 720))
+        return f"{inicio.strftime('%m/%Y')} a {fim.strftime('%m/%Y')}"
+
+    def _gerar_cnpjs(self) -> List[str]:
+        quantidade = random.randint(1, 3)
+        valores = []
+        for _ in range(quantidade):
+            numero = random.randint(0, 99999999999999)
+            valores.append(self._formatar_cnpj(numero))
+        return valores
+
+    @staticmethod
+    def _formatar_cnpj(valor: int) -> str:
+        s = f"{valor:014d}"
+        return f"{s[:2]}.{s[2:5]}.{s[5:8]}/{s[8:12]}-{s[12:]}"
+
+    def _gerar_bases(self) -> List[str]:
+        quantidade = random.randint(1, 3)
+        return random.sample(UF_CODES, k=quantidade)
+
+    # ---- controle de execução ----
+    def iniciar(self) -> None:
+        loop = self._ensure_loop()
+        self._start_worker(loop)
+        with self._lock:
+            if not self._queue_shadow and self._current_id is None:
+                self._estado = "ocioso"
+
+    def _start_worker(self, loop: asyncio.AbstractEventLoop) -> None:
+        def ensure_worker() -> None:
+            if self._worker_task is None or getattr(self._worker_task, "done", lambda: True)():
+                self._worker_task = loop.create_task(self._run(), name="tratamento-run")
+
+        self._run_on_loop(ensure_worker, wait=True, loop=loop)
+
+    def _enqueue(self, treatment_id: int, *, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
+        loop = loop or self._ensure_loop()
+
+        def push() -> None:
+            if self._queue is None:
+                raise RuntimeError("fila de tratamento não inicializada")
+            self._queue.put_nowait(treatment_id)
+            with self._lock:
+                self._queue_shadow.append(treatment_id)
+                if self._current_id is None:
+                    self._estado = "aguardando"
+
+        self._run_on_loop(push, loop=loop)
+
+    async def _run(self) -> None:
+        if self._queue is None:
+            self._queue = asyncio.Queue()
+        while True:
+            treatment_id = await self._queue.get()
+            with self._lock:
+                if treatment_id in self._queue_shadow:
+                    self._queue_shadow.remove(treatment_id)
+                self._current_id = treatment_id
+                self._estado = "processando"
+            try:
+                await self._process_plan(treatment_id)
+            except Exception:
+                logger.exception("Falha ao processar tratamento %s", treatment_id)
+            finally:
+                with self._lock:
+                    self._current_id = None
+                    if self._queue_shadow:
+                        self._estado = "aguardando"
+                    else:
+                        self._estado = "ocioso"
+                self._queue.task_done()
+
+    # ---- execução das etapas ----
+    async def _process_plan(self, treatment_id: int) -> None:
+        with SessionLocal() as db:
+            treatment_repo = TreatmentPlanRepository(db)
+            logs_repo = TreatmentLogRepository(db)
+            plan_repo = PlanRepository(db)
+
+            treatment = treatment_repo.get(treatment_id)
+            if treatment is None:
+                logger.warning("tratamento %s não encontrado", treatment_id)
+                return
+
+            # garante campos básicos
+            treatment.status = "processando"
+            db.commit()
+
+            for stage_id, stage_nome in STAGES:
+                self._marcar_inicio_etapa(treatment, stage_id)
+                logs_repo.add(
+                    treatment_id=treatment.id,
+                    etapa=stage_id,
+                    status="INICIO",
+                    mensagem=f"Iniciada {stage_nome}",
+                )
+                db.commit()
+
+                await asyncio.sleep(random.uniform(4.0, 7.0))
+
+                resultado = self._executar_etapa(
+                    db=db,
+                    plan_repo=plan_repo,
+                    logs_repo=logs_repo,
+                    treatment=treatment,
+                    stage_id=stage_id,
+                    stage_nome=stage_nome,
+                )
+
+                db.commit()
+
+                if resultado == "descartado":
+                    break
+
+            db.refresh(treatment)
+            if treatment.status not in ("rescindido", "descartado"):
+                treatment.status = "rescindido"
+                treatment.etapa_atual = 7
+                self._marcar_conclusao_etapa(treatment, 7, "Comunicação concluída")
+                db.commit()
+
+    def _executar_etapa(self, *, db, plan_repo, logs_repo, treatment: TreatmentPlan, stage_id: int, stage_nome: str) -> Optional[str]:
+        if stage_id == 1:
+            self._etapa1(treatment)
+            mensagem = "Dados de aproveitamento registrados"
+        elif stage_id == 2:
+            self._etapa2(treatment)
+            mensagem = "Análise de substituição concluída"
+        elif stage_id == 3:
+            self._etapa3(treatment)
+            mensagem = "Pesquisa de guias registrada"
+        elif stage_id == 4:
+            self._etapa4(treatment)
+            mensagem = "Lançamento de guias concluído"
+        elif stage_id == 5:
+            resultado = self._etapa5(treatment)
+            if resultado == "descartado":
+                logs_repo.add(
+                    treatment_id=treatment.id,
+                    etapa=stage_id,
+                    status="DESCARTADO",
+                    mensagem="Plano descartado após revalidação",
+                )
+                self._marcar_conclusao_etapa(treatment, stage_id, "Plano descartado")
+                db.commit()
+                treatment.status = "descartado"
+                self._marcar_cancelamento_restante(treatment, apartir=stage_id + 1)
+                return "descartado"
+            mensagem = "Situação do plano validada"
+        elif stage_id == 6:
+            self._etapa6(treatment, plan_repo)
+            mensagem = "Plano atualizado para RESCINDIDO"
+        elif stage_id == 7:
+            self._etapa7(treatment, plan_repo)
+            mensagem = "Comunicação registrada"
+        else:
+            mensagem = "Etapa desconhecida"
+
+        logs_repo.add(
+            treatment_id=treatment.id,
+            etapa=stage_id,
+            status="SUCESSO",
+            mensagem=mensagem,
+        )
+        self._marcar_conclusao_etapa(treatment, stage_id, mensagem)
+        return None
+
+    def _marcar_inicio_etapa(self, treatment: TreatmentPlan, stage_id: int) -> None:
+        stage = self._buscar_stage(treatment, stage_id)
+        agora = datetime.now(timezone.utc).isoformat()
+        stage["status"] = "processando"
+        stage["iniciado_em"] = stage.get("iniciado_em") or agora
+        stage["mensagem"] = ""
+        treatment.etapa_atual = stage_id
+
+    def _marcar_conclusao_etapa(self, treatment: TreatmentPlan, stage_id: int, mensagem: str) -> None:
+        stage = self._buscar_stage(treatment, stage_id)
+        stage["status"] = "concluido"
+        stage["finalizado_em"] = datetime.now(timezone.utc).isoformat()
+        stage["mensagem"] = mensagem
+
+    def _marcar_cancelamento_restante(self, treatment: TreatmentPlan, apartir: int) -> None:
+        for sid, _ in STAGES:
+            if sid >= apartir:
+                stage = self._buscar_stage(treatment, sid)
+                if stage["status"] != "concluido":
+                    stage["status"] = "cancelado"
+                    stage["mensagem"] = "Etapa não executada por descarte"
+
+    def _buscar_stage(self, treatment: TreatmentPlan, stage_id: int) -> dict:
+        for stage in treatment.etapas:
+            if stage["id"] == stage_id:
+                return stage
+        nome = dict(STAGES).get(stage_id, f"Etapa {stage_id}")
+        stage = {
+            "id": stage_id,
+            "nome": nome,
+            "status": "pendente",
+            "iniciado_em": None,
+            "finalizado_em": None,
+            "mensagem": "",
+        }
+        treatment.etapas.append(stage)
+        return stage
+
+    def _etapa1(self, treatment: TreatmentPlan) -> None:
+        houve_aproveitamento = random.choice(["Sim", "Não"])
+        texto = (
+            "CNPJs analisados: "
+            + ", ".join(treatment.cnpjs)
+            + f"\nPeríodo: {treatment.periodo}\nRazão social: {treatment.razao_social}\nHouve aproveitamento? {houve_aproveitamento}"
+        )
+        treatment.notas["E213_APROVEITAMENTO_RECOLHIMENTOS"] = texto
+        treatment.notas["E544_DATA_SOLICITACAO"] = ""
+        treatment.notas.setdefault("E544_PERIODO", treatment.periodo)
+        treatment.notas.setdefault("E544_CNPJS", "\n".join(treatment.cnpjs))
+        treatment.notas.setdefault("CNPJ_CEI", ", ".join(treatment.cnpjs))
+        treatment.notas.setdefault("RAZAO_SOCIAL", treatment.razao_social)
+        treatment.notas.setdefault("PLANO", treatment.numero_plano)
+        treatment.notas["E398_BASES"] = "\n".join(treatment.bases)
+
+    def _etapa2(self, treatment: TreatmentPlan) -> None:
+        has_overlap = random.choice([True, False])
+        if has_overlap:
+            inicio = date.today() - timedelta(days=random.randint(60, 240))
+            fim = inicio + timedelta(days=random.randint(60, 180))
+            competencias = f"{inicio.strftime('%m/%Y')} a {fim.strftime('%m/%Y')}"
+        else:
+            competencias = "Sem competências congruentes"
+        houve_substituicao = random.choice([True, False])
+        resultado = (
+            "Débitos confessados substituídos por notificação fiscal"
+            if houve_substituicao
+            else "Sem substituição"
+        )
+        texto = (
+            f"Há indícios de competências congruentes? {competencias}"
+            f"\nResultado: {resultado}"
+        )
+        treatment.notas["E206_SUBSTITUICAO_CONFISSAO_NOTIFICACAO"] = texto
+
+    def _etapa3(self, treatment: TreatmentPlan) -> None:
+        quantidade = random.randint(0, 5)
+        if quantidade == 0:
+            texto = "PESQUISA DE GUIAS SFG: NÃO HÁ GUIAS"
+        else:
+            texto = f"PESQUISA DE GUIAS SFG: {quantidade:02d} GUIAS LOCALIZADAS"
+        treatment.notas["PESQUISA_GUIAS_SFG"] = texto
+
+    def _etapa4(self, treatment: TreatmentPlan) -> None:
+        quantidade = random.randint(0, 5)
+        if quantidade == 0:
+            texto = "GUIAS LANÇADAS: NENHUMA GUIA PROCESSADA"
+        else:
+            texto = f"GUIAS LANÇADAS: {quantidade:02d} GUIAS PROCESSADAS"
+        treatment.notas["LANCAMENTO_GUIAS_FGE"] = texto
+
+    def _etapa5(self, treatment: TreatmentPlan) -> Optional[str]:
+        data_solicitacao = date.today() - timedelta(days=random.randint(100, 600))
+        parcelas = []
+        valor_base = random.uniform(350.0, 980.0)
+        for idx in range(4, 7):
+            valor = f"{valor_base + random.uniform(-40, 40):.2f}".replace(".", ",")
+            vencimento = (date.today() + timedelta(days=30 * (idx - 3))).strftime("%d/%m/%Y")
+            parcelas.append(f"{idx:03d}           {valor}              {vencimento}")
+        treatment.notas["E544_DATA_SOLICITACAO"] = data_solicitacao.strftime("%d/%m/%Y")
+        treatment.notas["E50H_PARCELAS_ATRASO"] = "\n".join(parcelas)
+
+        if random.random() <= 0.01:
+            return "descartado"
+        return None
+
+    def _etapa6(self, treatment: TreatmentPlan, plan_repo: PlanRepository) -> None:
+        hoje = date.today()
+        plan = plan_repo.get_by_numero(treatment.numero_plano)
+        if plan is None:
+            return
+        plan.situacao_atual = "RESCINDIDO"
+        plan.status = PlanStatus.RESCINDIDO
+        plan.data_rescisao = hoje
+        treatment.rescisao_data = hoje
+        treatment.notas["E554_DATA_RESCISAO_FGE"] = hoje.strftime("%d/%m/%Y")
+
+    def _etapa7(self, treatment: TreatmentPlan, plan_repo: PlanRepository) -> None:
+        metodo = random.choice(["CNS", "Email"])
+        data_comunicacao = date.today()
+        if metodo == "CNS":
+            ref = "NSU-" + "".join(random.choices(string.digits, k=8))
+        else:
+            ref = f"contato_{random.randint(100, 999)}@empresa.com"
+        treatment.notas["E554_DATA_COMUNICACAO"] = data_comunicacao.strftime("%d/%m/%Y")
+        treatment.notas["E554_METODO_COMUNICACAO"] = metodo
+        treatment.notas["E554_NSU_OU_EMAIL"] = ref
+        treatment.notas.setdefault("E554_NOME_DOSSIE", f"Dossie_{treatment.numero_plano}")
+        treatment.notas.setdefault("E554_DATA_FINALIZACAO_SIREP", date.today().strftime("%d/%m/%Y"))
+
+        plan = plan_repo.get_by_numero(treatment.numero_plano)
+        if plan:
+            plan.data_comunicacao = data_comunicacao
+            plan.metodo_comunicacao = metodo
+            plan.referencia_comunicacao = ref
+
+    # ---- consultas ----
+    def status(self) -> dict:
+        with SessionLocal() as db:
+            treatment_repo = TreatmentPlanRepository(db)
+            log_repo = TreatmentLogRepository(db)
+            planos = treatment_repo.list_all()
+            logs = log_repo.recentes(limit=40)
+
+        planos_data = []
+        for plano in planos:
+            planos_data.append(
+                {
+                    "id": plano.id,
+                    "plan_id": plano.plan_id,
+                    "numero_plano": plano.numero_plano,
+                    "razao_social": plano.razao_social,
+                    "status": plano.status,
+                    "etapa_atual": plano.etapa_atual,
+                    "periodo": plano.periodo,
+                    "cnpjs": plano.cnpjs,
+                    "bases": plano.bases,
+                    "rescisao_data": plano.rescisao_data.isoformat() if plano.rescisao_data else None,
+                    "etapas": plano.etapas,
+                }
+            )
+
+        logs_data = [
+            {
+                "id": log.id,
+                "treatment_id": log.treatment_id,
+                "etapa": log.etapa,
+                "status": log.status,
+                "mensagem": log.mensagem,
+                "created_at": log.created_at.isoformat() if log.created_at else None,
+            }
+            for log in logs
+        ]
+
+        return {
+            "estado": self.estado(),
+            "atual": self._current_id,
+            "fila": list(self._queue_shadow),
+            "planos": planos_data,
+            "logs": logs_data,
+        }
+
+
+tratamento = TratamentoService()

--- a/sirep/domain/schemas.py
+++ b/sirep/domain/schemas.py
@@ -36,6 +36,10 @@ class PlanOut(BaseModel):
     dt_parcela_atraso: Optional[date] = None
     representacao: Optional[str] = None
     status: PlanStatus
+    data_rescisao: Optional[date] = None
+    data_comunicacao: Optional[date] = None
+    metodo_comunicacao: Optional[str] = None
+    referencia_comunicacao: Optional[str] = None
 
     class Config:
         from_attributes = True
@@ -64,3 +68,41 @@ class JobStatus(BaseModel):
     started_at: datetime
     finished_at: Optional[datetime] = None
     info: Optional[str] = None
+
+
+class TreatmentStageOut(BaseModel):
+    id: int
+    nome: str
+    status: str
+    iniciado_em: Optional[datetime] = None
+    finalizado_em: Optional[datetime] = None
+    mensagem: Optional[str] = None
+
+
+class TreatmentPlanOut(BaseModel):
+    id: int
+    plan_id: int
+    numero_plano: str
+    razao_social: str
+    status: str
+    etapa_atual: int
+    periodo: Optional[str] = None
+    cnpjs: List[str]
+    bases: List[str]
+    rescisao_data: Optional[date] = None
+    etapas: List[TreatmentStageOut]
+
+    class Config:
+        from_attributes = True
+
+
+class TreatmentLogOut(BaseModel):
+    id: int
+    treatment_id: int
+    etapa: int
+    status: str
+    mensagem: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/sirep/infra/db.py
+++ b/sirep/infra/db.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 from sirep.infra.config import settings
 
@@ -18,4 +18,23 @@ SessionLocal = sessionmaker(
 def init_db() -> None:
     # importa Base aqui para evitar import circular
     from sirep.domain.models import Base
+
     Base.metadata.create_all(bind=_engine)
+
+    # Ajusta colunas novas em execuções antigas do sqlite.
+    with _engine.begin() as conn:
+        info = conn.execute(text("PRAGMA table_info(plans)")).fetchall()
+        existing = {row[1] for row in info}
+        alter_statements = []
+        if "data_rescisao" not in existing:
+            alter_statements.append("ALTER TABLE plans ADD COLUMN data_rescisao DATE")
+        if "data_comunicacao" not in existing:
+            alter_statements.append("ALTER TABLE plans ADD COLUMN data_comunicacao DATE")
+        if "metodo_comunicacao" not in existing:
+            alter_statements.append("ALTER TABLE plans ADD COLUMN metodo_comunicacao VARCHAR(16)")
+        if "referencia_comunicacao" not in existing:
+            alter_statements.append(
+                "ALTER TABLE plans ADD COLUMN referencia_comunicacao VARCHAR(128)"
+            )
+        for ddl in alter_statements:
+            conn.execute(text(ddl))

--- a/sirep/services/notepad.py
+++ b/sirep/services/notepad.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+
+
+def build_notepad_txt(notes: Dict[str, Any]) -> str:
+    """Monta o TXT padronizado. Para campos não preenchidos, mantém linha vazia."""
+
+    def g(key: str) -> str:
+        value = notes.get(key, "") if notes else ""
+        if value is None:
+            return ""
+        return str(value).strip()
+
+    lines: list[str] = []
+    add = lines.append
+
+    add("DEPURAÇÃO PARCELAMENTO PASSÍVEL DE RESCISÃO")
+    add("=================================================================================")
+    add(f"PLANO: {g('PLANO')}")
+    add(f"CNPJ/CEI: {g('CNPJ_CEI')}")
+    add(f"RAZÃO SOCIAL: {g('RAZAO_SOCIAL')}")
+    add("=================================================================================")
+    add("E50H – PARCELAS EM ATRASO")
+    add("Parcela | Valor Parcela Atualizado | Data Vencimento")
+    atrasos = g("E50H_PARCELAS_ATRASO")
+    if atrasos:
+        add(atrasos)
+    add("=================================================================================")
+    add("E544 – DETALHES DO PARCELAMENTO")
+    add(f"TIPO: {g('E544_TIPO')}")
+    add(f"DATA DE SOLICITAÇÃO: {g('E544_DATA_SOLICITACAO')}")
+    add(f"PERÍODO: {g('E544_PERIODO')}")
+    cn = g("E544_CNPJS")
+    add("CNPJ:")
+    if cn:
+        add(cn)
+    add("=================================================================================")
+    add("E398 – CONSULTA BASES MATRIZ E FILIAIS")
+    bs = g("E398_BASES")
+    inline_base = (bs if bs and "\n" not in bs else "").strip()
+    add("BASES: " + inline_base)
+    if bs and "\n" in bs:
+        add(bs)
+    add("=================================================================================")
+    add("E555 – ANÁLISE DE OUTRO PLANO EM DIA")
+    analise = g("E555_ANALISE_OUTRO_PLANO")
+    if analise:
+        add(analise)
+    add("=================================================================================")
+    add("E213 – APROVEITAMENTO DE RECOLHIMENTOS")
+    aproveitamento = g("E213_APROVEITAMENTO_RECOLHIMENTOS")
+    if aproveitamento:
+        add(aproveitamento)
+    add("=================================================================================")
+    add("E206 – SUBSTITUIÇÃO – CONFISSÃO x NOTIFICAÇÃO FISCAL")
+    substituicao = g("E206_SUBSTITUICAO_CONFISSAO_NOTIFICACAO")
+    if substituicao:
+        add(substituicao)
+    add("=================================================================================")
+    add("PESQUISA DE OCORRÊNCIAS 21")
+    oc21 = g("OC21_RESULTADOS")
+    oc21_exc = g("OC21_EXCLUSAO_GUIAS")
+    if oc21:
+        add(oc21)
+        if oc21_exc:
+            add(oc21_exc)
+    oc21_table = g("OC21_TABELA")
+    if oc21_table:
+        add(oc21_table)
+    add("=================================================================================")
+    add("PESQUISA DE GUIAS NO SFG")
+    pesquisa_guias = g("PESQUISA_GUIAS_SFG")
+    if pesquisa_guias:
+        add(pesquisa_guias)
+    add("=================================================================================")
+    add("LANÇAMENTO DE GUIAS NO FGE")
+    lancamento_guias = g("LANCAMENTO_GUIAS_FGE")
+    if lancamento_guias:
+        add(lancamento_guias)
+    add("=================================================================================")
+    add("PESQUISA DE DUPLICIDADE")
+    duplicidade = g("PESQUISA_DUPLICIDADE")
+    if duplicidade:
+        add(duplicidade)
+    add("=================================================================================")
+    add("E554 - RESCISÃO")
+    add(f"DATA DA RESCISÃO NO FGE: {g('E554_DATA_RESCISAO_FGE')}")
+    add(f"DATA DA COMUNICAÇÃO: {g('E554_DATA_COMUNICACAO')}")
+    add(f"MÉTODO DE COMUNICAÇÃO (CNS/EMAIL): {g('E554_METODO_COMUNICACAO')}")
+    add(f"NSU OU ENDEREÇO DE EMAIL: {g('E554_NSU_OU_EMAIL')}")
+    add(f"NOME DO DOSSIÊ: {g('E554_NOME_DOSSIE')}")
+    add(f"DATA DE FINALIZAÇÃO NO SIREP: {g('E554_DATA_FINALIZACAO_SIREP')}")
+    add("=================================================================================")
+    add("OUTRAS OBSERVAÇÕES (que julgar necessárias)")
+    obs_txt = g("OUTRAS_OBSERVACOES").strip("\n")
+    if obs_txt:
+        add(obs_txt)
+
+    return "\n".join(lines) + "\n"

--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -124,6 +124,45 @@
     .modal-body p{margin:0;font-size:14px;font-weight:400;color:#000}
     .modal-actions{display:flex;justify-content:center;padding:0 20px 18px;background:#f7f7f7}
     .modal-actions .modal-button{min-width:96px;font-size:13px}
+
+    /* Tratamentos */
+    .treatment-controls{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:14px}
+    .treatment-controls .muted{margin-left:4px}
+    .treatment-actions{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:14px}
+    .treatment-actions input[type="date"]{padding:6px 10px;border:1px solid var(--line);border-radius:8px;font:inherit}
+    .treatment-grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
+    .treatment-column{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px;display:flex;flex-direction:column;gap:10px}
+    #treatmentQueueTable{width:100%;border-collapse:collapse}
+    #treatmentQueueTable th,#treatmentQueueTable td{padding:8px 10px;border-bottom:1px solid var(--line);font-size:13px;text-align:left}
+    #treatmentQueueTable th{font-size:12px;color:#4b5563;font-weight:700;letter-spacing:.3px}
+    #treatmentQueueTable tbody tr:last-child td{border-bottom:0}
+    .queue-row.current{background:rgba(16,140,188,.08)}
+    .queue-row.rescindido{background:#ecfdf5}
+    .queue-row.descartado{background:#fef2f2}
+    .queue-badge{display:inline-block;padding:2px 8px;border-radius:999px;font-size:11px;font-weight:700;background:#f3f4f6;color:#111;text-transform:uppercase}
+    .treatment-summary{display:flex;flex-direction:column;gap:4px;font-size:13px;color:#111}
+    .treatment-summary strong{font-weight:800}
+    .treatment-empty{font-size:13px;color:var(--muted)}
+    .stage-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:10px}
+    .stage{border:1px solid var(--line);border-left-width:4px;border-radius:10px;padding:10px 12px;background:#f9fafb}
+    .stage-header{display:flex;justify-content:space-between;gap:10px;font-weight:700;font-size:13px;margin-bottom:4px}
+    .stage-status-label{font-weight:800;font-size:11px;text-transform:uppercase;color:var(--muted)}
+    .stage-dates{font-size:11px;color:var(--muted);display:flex;gap:12px;flex-wrap:wrap;margin-top:4px}
+    .stage.processando{border-left-color:#F7A600;background:#fff7ed}
+    .stage.processando .stage-status-label{color:#b45309}
+    .stage.concluido{border-left-color:#16a34a;background:#ecfdf5}
+    .stage.concluido .stage-status-label{color:#047857}
+    .stage.cancelado{border-left-color:#b91c1c;background:#fef2f2}
+    .stage.cancelado .stage-status-label{color:#b91c1c}
+    .stage.pendente{border-left-color:#d1d5db}
+    .treatment-downloads{display:flex;gap:10px;align-items:center;margin-top:6px}
+    .treatment-logs{margin-top:20px;background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px}
+    .treatment-logs table{width:100%;border-collapse:collapse}
+    .treatment-logs th,.treatment-logs td{padding:8px 10px;border-bottom:1px solid var(--line);font-size:12px;text-align:left}
+    .treatment-logs th{font-size:12px;color:#4b5563;font-weight:700;letter-spacing:.3px}
+    .treatment-logs tbody tr:last-child td{border-bottom:0}
+    .btn-link{appearance:none;border:1px solid var(--line);background:#fff;border-radius:8px;padding:6px 10px;font-weight:600;cursor:pointer}
+    .btn-link:hover{background:rgba(16,140,188,.08)}
   </style>
 </head>
 <body>
@@ -273,7 +312,60 @@
         </div>
       </section>
 
-      <section id="tab-tratamento" style="display:none"><p class="muted">Em breve.</p></section>
+      <section id="tab-tratamento" style="display:none">
+        <div class="treatment-controls">
+          <button id="btnTratamentoSeed">Gerar planos mock</button>
+          <button id="btnTratamentoIniciar" class="primary">Iniciar fila</button>
+          <span class="muted">Estado: <span id="tratamentoEstado">Ocioso</span></span>
+        </div>
+        <div class="treatment-actions">
+          <label class="muted" for="inputRescindidosData">Data para exportação:</label>
+          <input type="date" id="inputRescindidosData" aria-label="Data de rescisão" />
+          <button id="btnDownloadRescindidos" class="btn-link">Exportar Rescindidos_CNPJ.txt</button>
+        </div>
+        <div class="treatment-grid">
+          <div class="treatment-column" aria-live="polite">
+            <h3>Fila de planos</h3>
+            <div class="muted">Enquanto um plano estiver em tratamento os demais aguardam.</div>
+            <table id="treatmentQueueTable" aria-label="Fila de tratamentos">
+              <thead>
+                <tr>
+                  <th scope="col">Plano</th>
+                  <th scope="col">Razão social</th>
+                  <th scope="col">Status</th>
+                  <th scope="col">Etapa atual</th>
+                  <th scope="col">Ações</th>
+                </tr>
+              </thead>
+              <tbody id="tbodyTratamentoFila"></tbody>
+            </table>
+            <div id="tratamentoEmpty" class="treatment-empty" hidden>Nenhum plano em tratamento. Gere mocks para iniciar.</div>
+          </div>
+          <div class="treatment-column">
+            <h3>Plano em execução</h3>
+            <div id="tratamentoAtualResumo" class="treatment-summary">Selecione ou aguarde um plano iniciar.</div>
+            <ul id="listaEtapas" class="stage-list"></ul>
+            <div class="treatment-downloads">
+              <button id="btnDownloadNotepad" class="btn-link" disabled>Baixar bloco de notas (.txt)</button>
+            </div>
+          </div>
+        </div>
+        <div class="treatment-logs">
+          <h3>Logs das etapas</h3>
+          <table aria-label="Eventos de tratamento">
+            <thead>
+              <tr>
+                <th scope="col">Data e hora</th>
+                <th scope="col">Plano</th>
+                <th scope="col">Etapa</th>
+                <th scope="col">Status</th>
+                <th scope="col">Mensagem</th>
+              </tr>
+            </thead>
+            <tbody id="tbodyTratamentoLogs"></tbody>
+          </table>
+        </div>
+      </section>
     </div>
   </div>
 </main>
@@ -336,6 +428,15 @@ function formatDateTime(value,options){
   const opts={timeZone:TIMEZONE,...(options||{})};
   return date.toLocaleString("pt-BR",opts);
 }
+const TREATMENT_STAGE_NAMES={
+  1:"Etapa 1 – Aproveitamento de Recolhimentos",
+  2:"Etapa 2 – Substituição – Confissão x Notificação Fiscal",
+  3:"Etapa 3 – Pesquisa de Guias no SFG (PIG)",
+  4:"Etapa 4 – Lançamento de Guias no FGE (PIG)",
+  5:"Etapa 5 – Situação do Plano",
+  6:"Etapa 6 – Rescisão",
+  7:"Etapa 7 – Comunicação da Rescisão"
+};
 const el={
   btnIniciar:$("#btnIniciar"), btnPausar:$("#btnPausar"), btnContinuar:$("#btnContinuar"),
   barTotal:$("#barTotal"), lblTotal:$("#lblTotal"), ultima:$("#ultimaAtualizacao"),
@@ -349,7 +450,13 @@ const el={
   subtabPlanos:$("#subtabPlanos"), subtabOcorr:$("#subtabOcorr"), badgeOcorr:$("#badgeOcorr"),
   modalConcluido:$("#modalConcluido"), btnModalOk:$("#btnModalOk"), btnModalClose:$("#btnModalClose"),
   logsCard:$("#cardLogs"), logsHeader:$("#logsHeader"), logsBody:$("#logsBody"),
-  tbodyLogs:$("#tbodyLogs"), logsFrom:$("#logsFrom"), logsTo:$("#logsTo"), btnExportLogs:$("#btnExportLogs")
+  tbodyLogs:$("#tbodyLogs"), logsFrom:$("#logsFrom"), logsTo:$("#logsTo"), btnExportLogs:$("#btnExportLogs"),
+  tratamentoEstado:$("#tratamentoEstado"), btnTratamentoSeed:$("#btnTratamentoSeed"),
+  btnTratamentoIniciar:$("#btnTratamentoIniciar"), tbodyTratamentoFila:$("#tbodyTratamentoFila"),
+  listaEtapas:$("#listaEtapas"), tratamentoResumo:$("#tratamentoAtualResumo"),
+  btnDownloadNotepad:$("#btnDownloadNotepad"), tratamentoEmpty:$("#tratamentoEmpty"),
+  tbodyTratamentoLogs:$("#tbodyTratamentoLogs"), inputRescindidosData:$("#inputRescindidosData"),
+  btnDownloadRescindidos:$("#btnDownloadRescindidos")
 };
 let pagina=1,tamanho=10,totalPlanos={all:0,passiveis:0},maxPaginas=1;
 let paginaOcc=1,totalOcc=0,maxPaginasOcc=1,filtroSituacaoOcc="TODAS";
@@ -362,6 +469,10 @@ let filtroOcorrKeydownHandler=null;
 let logsOpen=false;
 let latestLogs=[];
 const MAX_LOGS=10;
+let tratamentoTimer=null;
+let tratamentoDados=null;
+let tratamentoLoading=false;
+let activeTab=null;
 
 function statusClass(s){
   const k=(s||"").toLowerCase();
@@ -762,6 +873,274 @@ function downloadBlob(blob,filename){
   a.remove(); URL.revokeObjectURL(url);
 }
 
+function setTratamentoEstado(estado){
+  if(!el.tratamentoEstado) return;
+  let label="Ocioso";
+  if(estado==="processando") label="Em execução";
+  else if(estado==="aguardando") label="Aguardando fila";
+  el.tratamentoEstado.textContent=label;
+}
+
+function formatTreatmentStatus(status){
+  const map={
+    pendente:"Pendente",
+    processando:"Processando",
+    rescindido:"Rescindido",
+    descartado:"Descartado"
+  };
+  const key=String(status||"").toLowerCase();
+  return map[key]||status||"";
+}
+
+function formatStageDisplayStatus(status){
+  const map={
+    pendente:"Pendente",
+    processando:"Em andamento",
+    concluido:"Concluída",
+    cancelado:"Cancelada"
+  };
+  const key=String(status||"").toLowerCase();
+  return map[key]||status||"";
+}
+
+function renderTratamentoResumo(plan){
+  if(!el.tratamentoResumo||!el.btnDownloadNotepad) return;
+  if(!plan){
+    el.tratamentoResumo.textContent="Selecione ou aguarde um plano iniciar.";
+    el.btnDownloadNotepad.disabled=true;
+    el.btnDownloadNotepad.dataset.planId="";
+    el.btnDownloadNotepad.dataset.numero="";
+    return;
+  }
+  const rescisao = plan.rescisao_data ? formatDateBR(plan.rescisao_data) : "—";
+  el.tratamentoResumo.innerHTML=`
+    <div class="treatment-summary">
+      <div><strong>Plano:</strong> ${plan.numero_plano}</div>
+      <div><strong>Razão social:</strong> ${plan.razao_social}</div>
+      <div><strong>CNPJs:</strong> ${Array.isArray(plan.cnpjs)?plan.cnpjs.join(", "):""}</div>
+      <div><strong>Bases:</strong> ${Array.isArray(plan.bases)?plan.bases.join(", "):""}</div>
+      <div><strong>Status:</strong> ${formatTreatmentStatus(plan.status)}</div>
+      <div><strong>Data da rescisão:</strong> ${rescisao}</div>
+    </div>`;
+  el.btnDownloadNotepad.disabled=false;
+  el.btnDownloadNotepad.dataset.planId=plan.id;
+  el.btnDownloadNotepad.dataset.numero=plan.numero_plano;
+}
+
+function renderTratamentoEtapas(plan){
+  if(!el.listaEtapas) return;
+  el.listaEtapas.innerHTML="";
+  if(!plan||!Array.isArray(plan.etapas)) return;
+  plan.etapas.forEach(stage=>{
+    const li=document.createElement("li");
+    const status=(stage.status||"").toLowerCase();
+    li.className=`stage ${status}`;
+    const nome=stage.nome||TREATMENT_STAGE_NAMES[stage.id]||`Etapa ${stage.id}`;
+    const inicio=stage.iniciado_em?formatDateTime(stage.iniciado_em,{day:"2-digit",month:"2-digit",year:"numeric",hour:"2-digit",minute:"2-digit"}):"—";
+    const fim=stage.finalizado_em?formatDateTime(stage.finalizado_em,{day:"2-digit",month:"2-digit",year:"numeric",hour:"2-digit",minute:"2-digit"}):"—";
+    li.innerHTML=`
+      <div class="stage-header">
+        <span>${stage.id}. ${nome}</span>
+        <span class="stage-status-label">${formatStageDisplayStatus(status)}</span>
+      </div>
+      <div class="stage-info">${stage.mensagem||""}</div>
+      <div class="stage-dates"><span>Início: ${inicio}</span><span>Término: ${fim}</span></div>
+    `;
+    el.listaEtapas.appendChild(li);
+  });
+}
+
+function renderTratamentoFila(data){
+  if(!el.tbodyTratamentoFila) return;
+  el.tbodyTratamentoFila.innerHTML="";
+  const planos=Array.isArray(data.planos)?data.planos:[];
+  const fila=Array.isArray(data.fila)?data.fila:[];
+  if(el.tratamentoEmpty) el.tratamentoEmpty.hidden=!!planos.length;
+  planos.forEach(plan=>{
+    const tr=document.createElement("tr");
+    tr.classList.add("queue-row");
+    if(plan.id===data.atual) tr.classList.add("current");
+    if(plan.status==="rescindido") tr.classList.add("rescindido");
+    if(plan.status==="descartado") tr.classList.add("descartado");
+    const pos=fila.indexOf(plan.id);
+    let badge="";
+    if(plan.id===data.atual) badge="Em execução";
+    else if(plan.status==="pendente"&&pos>=0) badge=`Na fila #${pos+1}`;
+    else if(plan.status==="rescindido") badge="Rescindido";
+    else if(plan.status==="descartado") badge="Descartado";
+    const badgeHtml=badge?`<span class="queue-badge">${badge}</span>`:"";
+    const etapaAtual=plan.etapa_atual?`${plan.etapa_atual} / 7`:"—";
+    const btn=`<button class="btn-link" data-action="download-notepad" data-plan-id="${plan.id}" data-numero="${plan.numero_plano}">Bloco (.txt)</button>`;
+    tr.innerHTML=`
+      <td>${plan.numero_plano}</td>
+      <td>${plan.razao_social}</td>
+      <td>${formatTreatmentStatus(plan.status)} ${badgeHtml}</td>
+      <td>${etapaAtual}</td>
+      <td>${btn}</td>
+    `;
+    el.tbodyTratamentoFila.appendChild(tr);
+  });
+}
+
+function formatLogStatus(status){
+  if(!status) return "";
+  const map={SUCESSO:"Sucesso",INICIO:"Início",DESCARTADO:"Descartado"};
+  const upper=String(status).toUpperCase();
+  if(map[upper]) return map[upper];
+  return upper.charAt(0)+upper.slice(1).toLowerCase();
+}
+
+function renderTratamentoLogs(logs,planos){
+  if(!el.tbodyTratamentoLogs) return;
+  el.tbodyTratamentoLogs.innerHTML="";
+  const map=new Map((Array.isArray(planos)?planos:[]).map(p=>[p.id,p]));
+  (Array.isArray(logs)?logs:[])
+    .slice()
+    .sort((a,b)=>{
+      const da=a.created_at?new Date(a.created_at).getTime():0;
+      const db=b.created_at?new Date(b.created_at).getTime():0;
+      return db-da;
+    })
+    .forEach(log=>{
+      const tr=document.createElement("tr");
+      const plan=map.get(log.treatment_id);
+      const etapaNome=TREATMENT_STAGE_NAMES[log.etapa]||`Etapa ${log.etapa}`;
+      const quando=log.created_at?formatDateTime(log.created_at,{day:"2-digit",month:"2-digit",year:"numeric",hour:"2-digit",minute:"2-digit",second:"2-digit"}):"";
+      tr.innerHTML=`
+        <td>${quando}</td>
+        <td>${plan?plan.numero_plano:"—"}</td>
+        <td>${etapaNome}</td>
+        <td>${formatLogStatus(log.status)}</td>
+        <td>${log.mensagem||""}</td>
+      `;
+      el.tbodyTratamentoLogs.appendChild(tr);
+    });
+}
+
+function atualizarTratamentoUI(data){
+  tratamentoDados=data;
+  setTratamentoEstado(data.estado);
+  const planos=Array.isArray(data.planos)?data.planos:[];
+  const atualId=data.atual;
+  const planoAtual=planos.find(p=>p.id===atualId)||planos.find(p=>p.status==="processando")||null;
+  renderTratamentoResumo(planoAtual);
+  renderTratamentoEtapas(planoAtual);
+  renderTratamentoFila(data);
+  renderTratamentoLogs(data.logs||[],planos);
+}
+
+async function carregarTratamentoStatus(){
+  if(tratamentoLoading) return;
+  tratamentoLoading=true;
+  try{
+    const data=await api("/tratamentos/status");
+    atualizarTratamentoUI(data);
+  }catch(e){
+    console.error("Falha ao carregar tratamentos",e);
+  }finally{
+    tratamentoLoading=false;
+  }
+}
+
+function startTratamentoPolling(){
+  stopTratamentoPolling();
+  tratamentoTimer=setInterval(()=>{carregarTratamentoStatus();},4000);
+}
+
+function stopTratamentoPolling(){
+  if(tratamentoTimer){
+    clearInterval(tratamentoTimer);
+    tratamentoTimer=null;
+  }
+}
+
+function ativarTratamentoTab(){
+  carregarTratamentoStatus();
+  startTratamentoPolling();
+}
+
+function desativarTratamentoTab(){
+  stopTratamentoPolling();
+}
+
+async function seedTratamento(){
+  if(!el.btnTratamentoSeed) return;
+  el.btnTratamentoSeed.disabled=true;
+  try{
+    await api("/tratamentos/seed?quantidade=3",{method:"POST"});
+    await api("/tratamentos/iniciar",{method:"POST"});
+    await carregarTratamentoStatus();
+  }catch(e){
+    console.error(e);
+    alert("Não foi possível gerar os planos de tratamento.");
+  }finally{
+    el.btnTratamentoSeed.disabled=false;
+  }
+}
+
+async function iniciarTratamento(){
+  if(!el.btnTratamentoIniciar) return;
+  el.btnTratamentoIniciar.disabled=true;
+  try{
+    await api("/tratamentos/iniciar",{method:"POST"});
+    await carregarTratamentoStatus();
+  }catch(e){
+    console.error(e);
+    alert("Não foi possível iniciar a fila de tratamento.");
+  }finally{
+    el.btnTratamentoIniciar.disabled=false;
+  }
+}
+
+async function downloadTratamentoNotepad(id,numero){
+  if(!id) return;
+  try{
+    const res=await fetch(`/tratamentos/${id}/notepad`);
+    if(!res.ok) throw new Error(`HTTP ${res.status}`);
+    const blob=await res.blob();
+    const filename=numero?`bloco_plano_${numero}.txt`:`bloco_plano_${id}.txt`;
+    downloadBlob(blob,filename);
+  }catch(e){
+    console.error(e);
+    alert("Não foi possível baixar o bloco de notas do plano.");
+  }
+}
+
+async function downloadRescindidos(){
+  if(!el.inputRescindidosData||!el.btnDownloadRescindidos) return;
+  const value=el.inputRescindidosData.value;
+  if(!value){
+    alert("Informe a data para gerar o arquivo de rescindidos.");
+    return;
+  }
+  el.btnDownloadRescindidos.disabled=true;
+  try{
+    const res=await fetch(`/tratamentos/rescindidos-txt?data=${value}`);
+    if(!res.ok) throw new Error(`HTTP ${res.status}`);
+    const blob=await res.blob();
+    downloadBlob(blob,"Rescindidos_CNPJ.txt");
+  }catch(e){
+    console.error(e);
+    alert("Não foi possível gerar o arquivo Rescindidos_CNPJ.txt.");
+  }finally{
+    el.btnDownloadRescindidos.disabled=false;
+  }
+}
+
+function setActiveTab(name){
+  if(!name) return;
+  if(name===activeTab) return;
+  activeTab=name;
+  document.querySelectorAll(".tab").forEach(tab=>{
+    tab.classList.toggle("active",tab.dataset.tab===name);
+  });
+  document.querySelectorAll(".content > section").forEach(section=>{
+    section.style.display=section.id===`tab-${name}`?"block":"none";
+  });
+  if(name==="tratamento") ativarTratamentoTab();
+  else desativarTratamentoTab();
+}
+
 function toISODate(val){
   return /^\d{4}-\d{2}-\d{2}$/.test(val)?val:"";
 }
@@ -800,6 +1179,53 @@ async function exportLogsXlsx(){
 if(el.btnExportLogs){
   el.btnExportLogs.addEventListener("click",(e)=>{e.preventDefault();exportLogsXlsx();});
 }
+
+document.querySelectorAll(".tab").forEach(tab=>{
+  tab.addEventListener("click",event=>{
+    event.preventDefault();
+    const target=tab.dataset.tab;
+    if(target) setActiveTab(target);
+  });
+});
+
+if(el.btnTratamentoSeed){
+  el.btnTratamentoSeed.addEventListener("click",event=>{
+    event.preventDefault();
+    seedTratamento();
+  });
+}
+
+if(el.btnTratamentoIniciar){
+  el.btnTratamentoIniciar.addEventListener("click",event=>{
+    event.preventDefault();
+    iniciarTratamento();
+  });
+}
+
+if(el.btnDownloadNotepad){
+  el.btnDownloadNotepad.addEventListener("click",event=>{
+    event.preventDefault();
+    const id=Number(el.btnDownloadNotepad.dataset.planId||"0");
+    const numero=el.btnDownloadNotepad.dataset.numero||"";
+    if(id) downloadTratamentoNotepad(id,numero);
+  });
+}
+
+if(el.btnDownloadRescindidos){
+  el.btnDownloadRescindidos.addEventListener("click",event=>{
+    event.preventDefault();
+    downloadRescindidos();
+  });
+}
+
+document.addEventListener("click",event=>{
+  const target=event.target.closest('[data-action="download-notepad"]');
+  if(!target) return;
+  event.preventDefault();
+  const id=Number(target.getAttribute("data-plan-id")||"0");
+  const numero=target.getAttribute("data-numero")||"";
+  if(id) downloadTratamentoNotepad(id,numero);
+});
 
 el.subtabPlanos.onclick=()=>{fecharFiltroOcorrMenu();el.subtabPlanos.classList.add("active");el.subtabOcorr.classList.remove("active");$("#wrapPlanos").style.display="block";$("#wrapOcorr").style.display="none";};
 el.subtabOcorr.onclick=()=>{fecharFiltroOcorrMenu();el.subtabOcorr.classList.add("active");el.subtabPlanos.classList.remove("active");$("#wrapPlanos").style.display="none";$("#wrapOcorr").style.display="block";carregarOcorrencias();};
@@ -857,6 +1283,10 @@ document.addEventListener("keydown",event=>{
 });
 
 document.addEventListener("DOMContentLoaded", async()=>{
+  if(el.inputRescindidosData){
+    try{el.inputRescindidosData.value=new Date().toISOString().slice(0,10);}catch(_e){}
+  }
+  setActiveTab("gestao");
   await carregarStatus();
   await carregarPlanos();
   startPolling();

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_tratamentos_endpoints.py
+++ b/tests/test_tratamentos_endpoints.py
@@ -1,0 +1,86 @@
+import pytest
+from fastapi.testclient import TestClient
+from datetime import date
+
+from sirep.app.api import app
+from sirep.domain.enums import PlanStatus
+from sirep.domain.models import Plan, TreatmentPlan
+from sirep.infra.db import SessionLocal, init_db
+
+
+@pytest.fixture
+def client():
+    init_db()
+    with SessionLocal() as db:
+        db.query(TreatmentPlan).delete()
+        db.query(Plan).delete()
+        db.commit()
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_seed_tratamentos(client: TestClient):
+    response = client.post("/tratamentos/seed", params={"quantidade": 1})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["criados"] == 1
+    assert isinstance(payload["ids"], list)
+    assert payload["ids"]
+
+    status = client.get("/tratamentos/status")
+    assert status.status_code == 200
+    body = status.json()
+    assert "planos" in body
+    assert isinstance(body["planos"], list)
+    assert body["planos"]
+    first = body["planos"][0]
+    assert "numero_plano" in first
+    assert "etapas" in first
+
+
+def test_tratamento_notepad_endpoint(client: TestClient):
+    client.post("/tratamentos/seed", params={"quantidade": 1})
+    status = client.get("/tratamentos/status").json()
+    plan_id = status["planos"][0]["id"]
+
+    response = client.get(f"/tratamentos/{plan_id}/notepad")
+    assert response.status_code == 200
+    assert "DEPURAÇÃO PARCELAMENTO" in response.text
+    assert "Content-Disposition" in response.headers
+
+
+def test_rescindidos_txt_endpoint(client: TestClient):
+    hoje = date.today()
+    with SessionLocal() as db:
+        plano = Plan(
+            numero_plano="900001",
+            situacao_atual="RESCINDIDO",
+            saldo=100.0,
+            status=PlanStatus.RESCINDIDO,
+            data_rescisao=hoje,
+        )
+        db.add(plano)
+        db.flush()
+
+        tratamento = TreatmentPlan(
+            plan_id=plano.id,
+            numero_plano=plano.numero_plano,
+            razao_social="EMPRESA TESTE LTDA",
+            status="rescindido",
+            etapa_atual=7,
+            periodo="01/2020 a 12/2020",
+            cnpjs=["12.345.678/0001-90", "98.765.432/0001-09"],
+            notas={},
+            etapas=[],
+            bases=["RJ", "SP"],
+            rescisao_data=hoje,
+        )
+        db.add(tratamento)
+        db.commit()
+
+    response = client.get(f"/tratamentos/rescindidos-txt?data={hoje.isoformat()}")
+    assert response.status_code == 200
+    body = response.text
+    assert "12345678000190" in body
+    assert "98765432000109" in body
+    assert response.headers.get("content-disposition", "").startswith("attachment")


### PR DESCRIPTION
## Summary
- extend the domain to persist tratamento data, logs and communication metadata on plans
- add the tratamento service, API endpoints, and notepad builder to drive the seven-step workflow and exports
- build the Tratamento UI with queue controls, stage visualization, and downloads backed by automated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d047dbb49483239eb1644b9269d505