### PR TITLE
Handle missing tzdata gracefully

### DIFF
--- a/sirep/app/api.py
+++ b/sirep/app/api.py
@@ -6,7 +6,7 @@ from datetime import date, datetime, time, timezone
 from io import BytesIO
 from pathlib import Path
 from typing import Optional
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from zipfile import ZipFile, ZIP_DEFLATED
 
 from fastapi import FastAPI, HTTPException, Query, Request
@@ -36,7 +36,13 @@ app = FastAPI(title="SIREP 2.0", version=__version__)
 ui_dir = Path(__file__).resolve().parent.parent / "ui"
 app.mount("/app", StaticFiles(directory=str(ui_dir), html=True), name="ui")
 
-DISPLAY_TZ = ZoneInfo("America/Sao_Paulo")
+try:
+    DISPLAY_TZ = ZoneInfo("America/Sao_Paulo")
+except ZoneInfoNotFoundError:
+    logger.warning(
+        "Fuso horário 'America/Sao_Paulo' não encontrado; usando UTC como fallback"
+    )
+    DISPLAY_TZ = timezone.utc
 
 CONTENT_TYPES_XML = """<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
 <Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">

--- a/sirep/pyproject.toml
+++ b/sirep/pyproject.toml
@@ -10,4 +10,5 @@ dependencies = [
   "pydantic-settings>=2.4.0",
   "tenacity>=9.0.0",
   "python-dotenv>=1.0.1",
+  "tzdata>=2024.1",
 ]


### PR DESCRIPTION
## Summary
- avoid crashing API startup when the local tz database is missing by falling back to UTC
- add the tzdata package to the project dependencies for environments without system tzinfo

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d0801b69608323adbf4427ef4e7610