### PR TITLE
Ajusta layout da fila de planos no tratamento

### DIFF
--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -5,7 +5,7 @@
   <title>SIREP 2.0</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <style>
-    :root{--accent:#0039BA;--text:#111;--muted:#6b7280;--line:#e5e7eb;--bg:#fff;--hdr-a:#0B5FA8;--hdr-b:#108CBC;--hdr-c:#49C3B6;--prog-a:#ef7d00;--prog-b:#F7A600}
+    :root{--accent:#0039BA;--text:#111;--muted:#6b7280;--line:#e5e7eb;--bg:#fff;--hdr-a:#0B5FA8;--hdr-b:#108CBC;--hdr-c:#49C3B6;--prog-a:#ef7d00;--prog-b:#F7A600;--queue-height:520px}
     *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,Segoe UI,Roboto}
     header{position:sticky;top:0;z-index:10;background:linear-gradient(90deg,var(--hdr-a),var(--hdr-b),var(--hdr-c));color:#fff}
     .top{display:flex;align-items:center;justify-content:center;padding:12px 16px;position:relative}
@@ -132,11 +132,17 @@
     .treatment-actions{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:14px}
     .treatment-actions input[type="date"]{padding:6px 10px;border:1px solid var(--line);border-radius:8px;font:inherit}
     .treatment-grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
-    .treatment-column{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px;display:flex;flex-direction:column;gap:10px}
+    .treatment-column{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px;display:flex;flex-direction:column;gap:10px;min-height:0}
     #treatmentQueueTable{width:100%;border-collapse:collapse}
     #treatmentQueueTable th,#treatmentQueueTable td{padding:8px 10px;border-bottom:1px solid var(--line);font-size:13px;text-align:left}
     #treatmentQueueTable th{font-size:12px;color:#4b5563;font-weight:700;letter-spacing:.3px}
     #treatmentQueueTable tbody tr:last-child td{border-bottom:0}
+    .queue-column{height:min(var(--queue-height),70vh)}
+    .queue-column .treatment-queue-scroll{flex:1;min-height:0;overflow:auto;padding-right:4px;scrollbar-width:thin;scrollbar-color:rgba(17,24,39,.35) transparent}
+    .queue-column .treatment-queue-scroll table{margin-bottom:0}
+    .queue-column .treatment-queue-scroll::-webkit-scrollbar{width:8px}
+    .queue-column .treatment-queue-scroll::-webkit-scrollbar-thumb{background:rgba(17,24,39,.25);border-radius:999px}
+    .queue-column .treatment-queue-scroll:hover::-webkit-scrollbar-thumb{background:rgba(17,24,39,.35)}
     .queue-row.current{background:rgba(16,140,188,.08)}
     .queue-row.rescindido{background:#ecfdf5}
     .queue-row.descartado{background:#fef2f2}
@@ -323,22 +329,24 @@
           <button id="btnDownloadRescindidos" class="btn-link">Exportar Rescindidos_CNPJ.txt</button>
         </div>
         <div class="treatment-grid">
-          <div class="treatment-column" aria-live="polite">
+          <div class="treatment-column queue-column" aria-live="polite">
             <h3>Fila de planos</h3>
             <div class="muted">Enquanto um plano estiver em tratamento os demais aguardam.</div>
-            <table id="treatmentQueueTable" aria-label="Fila de tratamentos">
-              <thead>
-                <tr>
-                  <th scope="col">Plano</th>
-                  <th scope="col">Razão social</th>
-                  <th scope="col">Status</th>
-                  <th scope="col">Etapa atual</th>
-                  <th scope="col">Ações</th>
-                </tr>
-              </thead>
-              <tbody id="tbodyTratamentoFila"></tbody>
-            </table>
-            <div id="tratamentoEmpty" class="treatment-empty" hidden>Nenhum plano em tratamento. Migre planos para iniciar.</div>
+            <div class="treatment-queue-scroll" role="region" aria-label="Fila de planos em espera">
+              <table id="treatmentQueueTable" aria-label="Fila de tratamentos">
+                <thead>
+                  <tr>
+                    <th scope="col">Plano</th>
+                    <th scope="col">Razão social</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Etapa atual</th>
+                    <th scope="col">Ações</th>
+                  </tr>
+                </thead>
+                <tbody id="tbodyTratamentoFila"></tbody>
+              </table>
+              <div id="tratamentoEmpty" class="treatment-empty" hidden>Nenhum plano em tratamento. Migre planos para iniciar.</div>
+            </div>
           </div>
           <div class="treatment-column">
             <h3>Plano em execução</h3>


### PR DESCRIPTION
## Resumo
- define uma altura fixa (via variável CSS) para o card de fila de planos
- encapsula a tabela em um contêiner rolável com estilo de barra customizado
- mantém o aviso de fila vazia dentro da área com rolagem para preservar o layout

## Testes
- `pytest` *(falha: ambiente sem a dependência httpx necessária para o testclient do FastAPI)*

------
https://chatgpt.com/codex/tasks/task_e_68d089e0a4408323ab36ad3311d01407