### PR TITLE
Atualiza UI de tratamento com plano atual e tabela

### DIFF
--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -14,6 +14,7 @@
     .icon{width:22px;height:22px;display:inline-flex;align-items:center;justify-content:center;border-radius:8px;background:rgba(255,255,255,.12);cursor:pointer}
     main{max-width:1100px;margin:18px auto;padding:0 14px}
     .card{background:#fff;border:1px solid var(--line);border-radius:14px;box-shadow:0 8px 20px rgba(0,0,0,.06)}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
     .tabs{display:flex;border-bottom:1px solid var(--line)}
     .tab{padding:12px 16px;cursor:pointer;font-weight:600;font-size:15px;border-bottom:2px solid transparent}
     .tab.active{color:var(--accent);border-bottom-color:var(--accent)}
@@ -131,14 +132,14 @@
     .treatment-controls .muted{margin-left:4px}
     .treatment-actions{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:14px}
     .treatment-actions input[type="date"]{padding:6px 10px;border:1px solid var(--line);border-radius:8px;font:inherit}
-    .treatment-grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
+    .treatment-grid{display:flex;flex-direction:column;gap:16px}
     .treatment-column{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px;display:flex;flex-direction:column;gap:10px;min-height:0}
     #treatmentQueueTable{width:100%;border-collapse:collapse}
     #treatmentQueueTable th,#treatmentQueueTable td{padding:8px 10px;border-bottom:1px solid var(--line);font-size:13px;text-align:left}
     #treatmentQueueTable th{font-size:12px;color:#4b5563;font-weight:700;letter-spacing:.3px}
     #treatmentQueueTable tbody tr:last-child td{border-bottom:0}
-    .queue-column{height:min(var(--queue-height),70vh)}
-    .queue-column .treatment-queue-scroll{flex:1;min-height:0;overflow:auto;padding-right:4px;scrollbar-width:thin;scrollbar-color:rgba(17,24,39,.35) transparent}
+    .queue-column{height:auto}
+    .queue-column .treatment-queue-scroll{flex:0 1 auto;max-height:240px;overflow:auto;padding-right:4px;scrollbar-width:thin;scrollbar-color:rgba(17,24,39,.35) transparent}
     .queue-column .treatment-queue-scroll table{margin-bottom:0}
     .queue-column .treatment-queue-scroll::-webkit-scrollbar{width:8px}
     .queue-column .treatment-queue-scroll::-webkit-scrollbar-thumb{background:rgba(17,24,39,.25);border-radius:999px}
@@ -148,6 +149,12 @@
     .queue-row.descartado{background:#fef2f2}
     .queue-badge{display:inline-block;padding:2px 8px;border-radius:999px;font-size:11px;font-weight:700;background:#f3f4f6;color:#111;text-transform:uppercase}
     .treatment-empty{font-size:13px;color:var(--muted)}
+    .treatment-card-header{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
+    .treatment-card-header h3{margin:0}
+    .table-search-input{min-width:220px;padding:8px 12px;border:1px solid var(--line);border-radius:10px;font:inherit}
+    .table-search-input:focus{outline:2px solid rgba(16,140,188,.25);outline-offset:1px}
+    .treatment-table-scroll{overflow:auto}
+    .treatment-table-footer{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap;margin-top:8px}
     .treatment-logs{margin-top:20px}
     .treatment-logs .logs-actions{flex-wrap:wrap;justify-content:flex-end}
     .btn-link{appearance:none;border:1px solid var(--line);background:#fff;border-radius:8px;padding:6px 10px;font-weight:600;cursor:pointer}
@@ -315,22 +322,60 @@
         </div>
         <div class="treatment-grid">
           <div class="treatment-column queue-column" aria-live="polite">
-            <h3>Fila de planos</h3>
+            <h3>PLANO EM EXECUÇÃO</h3>
             <div class="muted">Enquanto um plano estiver em tratamento os demais aguardam.</div>
-            <div class="treatment-queue-scroll" role="region" aria-label="Fila de planos em espera">
-              <table id="treatmentQueueTable" aria-label="Fila de tratamentos">
+            <div class="treatment-queue-scroll" role="region" aria-label="Plano em execução">
+              <table id="treatmentQueueTable" aria-label="Plano em execução">
                 <thead>
                   <tr>
-                    <th scope="col">Plano</th>
-                    <th scope="col">Razão social</th>
-                    <th scope="col">Status</th>
-                    <th scope="col">Etapa atual</th>
-                    <th scope="col">Ações</th>
+                    <th scope="col">PLANO</th>
+                    <th scope="col">CNPJ</th>
+                    <th scope="col">RAZÃO SOCIAL</th>
+                    <th scope="col">STATUS</th>
+                    <th scope="col">ETAPA ATUAL</th>
                   </tr>
                 </thead>
                 <tbody id="tbodyTratamentoFila"></tbody>
               </table>
-              <div id="tratamentoEmpty" class="treatment-empty" hidden>Nenhum plano em tratamento. Migre planos para iniciar.</div>
+              <div id="tratamentoEmpty" class="treatment-empty" hidden>Nenhum plano em execução no momento.</div>
+            </div>
+          </div>
+
+          <div class="treatment-column" aria-live="polite">
+            <div class="treatment-card-header">
+              <h3>TABELA DE PLANOS</h3>
+              <label class="sr-only" for="treatmentSearch">Buscar planos</label>
+              <input
+                type="search"
+                id="treatmentSearch"
+                class="table-search-input"
+                placeholder="Digite o Número do Plano, CNPJ ou Razão Social..."
+                autocomplete="off"
+              />
+            </div>
+            <div class="treatment-table-scroll" role="region" aria-label="Tabela de planos do tratamento">
+              <table id="treatmentPlansTable" aria-label="Planos do tratamento">
+                <thead>
+                  <tr>
+                    <th scope="col">PLANO</th>
+                    <th scope="col">CNPJ</th>
+                    <th scope="col">RAZÃO SOCIAL</th>
+                    <th scope="col">TIPO</th>
+                    <th scope="col">SITUAÇÃO</th>
+                    <th scope="col">DT SITUAÇÃO</th>
+                    <th scope="col">AÇÕES</th>
+                  </tr>
+                </thead>
+                <tbody id="tbodyTratamentoTabela"></tbody>
+              </table>
+            </div>
+            <div class="treatment-table-footer">
+              <div class="muted" id="treatmentTableInfo">Nenhum plano encontrado.</div>
+              <div>
+                <button id="btnTreatmentTablePrev">Anterior</button>
+                <span class="muted" id="treatmentTablePageLabel" style="margin:0 6px">pág. 1 de 1</span>
+                <button id="btnTreatmentTableNext">Próximo</button>
+              </div>
             </div>
           </div>
         </div>
@@ -527,12 +572,18 @@ const el={
   tratamentoEstado:$("#tratamentoEstado"), btnTratamentoSeed:$("#btnTratamentoSeed"),
   btnTratamentoIniciar:$("#btnTratamentoIniciar"), btnTratamentoPausar:$("#btnTratamentoPausar"),
   btnTratamentoContinuar:$("#btnTratamentoContinuar"), tbodyTratamentoFila:$("#tbodyTratamentoFila"),
-  tratamentoEmpty:$("#tratamentoEmpty"),
+  tratamentoEmpty:$("#tratamentoEmpty"), treatmentSearch:$("#treatmentSearch"),
+  tbodyTratamentoTabela:$("#tbodyTratamentoTabela"), treatmentTableInfo:$("#treatmentTableInfo"),
+  treatmentTablePageLabel:$("#treatmentTablePageLabel"), btnTreatmentTablePrev:$("#btnTreatmentTablePrev"),
+  btnTreatmentTableNext:$("#btnTreatmentTableNext"),
   tbodyTratamentoLogs:$("#tbodyTratamentoLogs"), inputRescindidosData:$("#inputRescindidosData"),
   btnDownloadRescindidos:$("#btnDownloadRescindidos")
 };
 let pagina=1,tamanho=10,totalPlanos={all:0,passiveis:0},maxPaginas=1;
 let paginaOcc=1,totalOcc=0,maxPaginasOcc=1,filtroSituacaoOcc="TODAS";
+const TREATMENT_TABLE_PAGE_SIZE=10;
+let treatmentTablePage=1;
+let treatmentTableSearchTerm="";
 let timer=null;
 let ultimoEstado=null;
 let filtroOcorrOutsideHandler=null;
@@ -555,6 +606,17 @@ function statusClass(s){
   if(k.includes("descart")) return "descartado";
   if(k.includes("paus")) return "pausado";
   return "sucesso";
+}
+
+function normalizeText(value){
+  const str=String(value??"");
+  if(typeof str.normalize==="function"){
+    return str
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g,"")
+      .toLowerCase();
+  }
+  return str.toLowerCase();
 }
 
 function fmtLogDate(isoStr){
@@ -1004,32 +1066,114 @@ function renderTratamentoFila(data){
   if(!el.tbodyTratamentoFila) return;
   el.tbodyTratamentoFila.innerHTML="";
   const planos=Array.isArray(data.planos)?data.planos:[];
-  const fila=Array.isArray(data.fila)?data.fila:[];
-  if(el.tratamentoEmpty) el.tratamentoEmpty.hidden=!!planos.length;
-  planos.forEach(plan=>{
-    const tr=document.createElement("tr");
-    tr.classList.add("queue-row");
-    if(plan.id===data.atual) tr.classList.add("current");
-    if(plan.status==="rescindido") tr.classList.add("rescindido");
-    if(plan.status==="descartado") tr.classList.add("descartado");
-    const pos=fila.indexOf(plan.id);
-    let badge="";
-    if(plan.id===data.atual) badge="Em execução";
-    else if(plan.status==="pendente"&&pos>=0) badge=`Na fila #${pos+1}`;
-    else if(plan.status==="rescindido") badge="Rescindido";
-    else if(plan.status==="descartado") badge="Descartado";
-    const badgeHtml=badge?`<span class="queue-badge">${badge}</span>`:"";
-    const etapaAtual=plan.etapa_atual?`${plan.etapa_atual} / 7`:"—";
-    const btn=`<button class="btn-link" data-action="download-notepad" data-plan-id="${plan.id}" data-numero="${plan.numero_plano}">Bloco (.txt)</button>`;
-    tr.innerHTML=`
-      <td>${plan.numero_plano}</td>
-      <td>${plan.razao_social}</td>
-      <td>${formatTreatmentStatus(plan.status)} ${badgeHtml}</td>
+  let atual=null;
+  const atualId=typeof data.atual==="number"?data.atual:null;
+  if(atualId!=null){
+    atual=planos.find(item=>item.id===atualId)||null;
+  }
+  if(!atual){
+    atual=planos.find(item=>(item.status||"").toLowerCase()==="processando")||null;
+  }
+  if(!atual){
+    if(el.tratamentoEmpty) el.tratamentoEmpty.hidden=false;
+    return;
+  }
+  if(el.tratamentoEmpty) el.tratamentoEmpty.hidden=true;
+  const tr=document.createElement("tr");
+  tr.classList.add("queue-row");
+  const statusKey=(atual.status||"").toLowerCase();
+  if(statusKey==="processando") tr.classList.add("current");
+  if(statusKey==="rescindido") tr.classList.add("rescindido");
+  if(statusKey==="descartado") tr.classList.add("descartado");
+  const etapaAtual=atual.etapa_atual?`${atual.etapa_atual} / 7`:"—";
+  const cnpjs=Array.isArray(atual.cnpjs)&&atual.cnpjs.length
+    ? atual.cnpjs.join("<br>")
+    : "—";
+  tr.innerHTML=`
+      <td>${atual.numero_plano||"—"}</td>
+      <td>${cnpjs}</td>
+      <td>${atual.razao_social||"—"}</td>
+      <td>${formatTreatmentStatus(atual.status)}</td>
       <td>${etapaAtual}</td>
-      <td>${btn}</td>
     `;
-    el.tbodyTratamentoFila.appendChild(tr);
+  el.tbodyTratamentoFila.appendChild(tr);
+}
+
+function filterTreatmentPlanos(planos){
+  const busca=treatmentTableSearchTerm.trim();
+  if(!busca) return planos;
+  const normalizedBusca=normalizeText(busca);
+  const buscaNumerica=busca.replace(/\D+/g,"");
+  return planos.filter(plan=>{
+    const numero=String(plan.numero_plano||"").toLowerCase();
+    if(numero.includes(normalizedBusca)||numero.includes(busca.toLowerCase())) return true;
+    const razao=normalizeText(plan.razao_social||"");
+    if(razao.includes(normalizedBusca)) return true;
+    const cnpjs=Array.isArray(plan.cnpjs)?plan.cnpjs:[];
+    for(const cnpj of cnpjs){
+      const normal=normalizeText(cnpj);
+      if(normal.includes(normalizedBusca)) return true;
+      if(buscaNumerica&&cnpj.replace(/\D+/g,"").includes(buscaNumerica)) return true;
+    }
+    return false;
   });
+}
+
+function renderTratamentoTabela(){
+  if(!el.tbodyTratamentoTabela) return;
+  const planos=tratamentoDados&&Array.isArray(tratamentoDados.planos)?tratamentoDados.planos:[];
+  const filtrados=filterTreatmentPlanos(planos);
+  const total=filtrados.length;
+  const totalPaginas=Math.max(1,Math.ceil(total/TREATMENT_TABLE_PAGE_SIZE));
+  if(treatmentTablePage>totalPaginas){
+    treatmentTablePage=totalPaginas;
+  }
+  const inicio=(treatmentTablePage-1)*TREATMENT_TABLE_PAGE_SIZE;
+  const fim=inicio+TREATMENT_TABLE_PAGE_SIZE;
+  const paginaItens=filtrados.slice(inicio,fim);
+  el.tbodyTratamentoTabela.innerHTML="";
+  if(!paginaItens.length){
+    const tr=document.createElement("tr");
+    tr.innerHTML='<td colspan="7" class="muted">Nenhum plano encontrado.</td>';
+    el.tbodyTratamentoTabela.appendChild(tr);
+  }else{
+    paginaItens.forEach(plan=>{
+      const cnpjs=Array.isArray(plan.cnpjs)&&plan.cnpjs.length?plan.cnpjs.join("<br>"):"—";
+      const situacao=plan.status?formatTreatmentStatus(plan.status):"—";
+      const dtSituacao=plan.rescisao_data?formatDateBR(plan.rescisao_data):"—";
+      const btn=`<button class="btn-link" data-action="download-notepad" data-plan-id="${plan.id}" data-numero="${plan.numero_plano}">Dados (.txt)</button>`;
+      const tipo=Array.isArray(plan.bases)&&plan.bases.length?plan.bases.join(", "):"—";
+      const tr=document.createElement("tr");
+      tr.innerHTML=`
+        <td>${plan.numero_plano||"—"}</td>
+        <td>${cnpjs}</td>
+        <td>${plan.razao_social||"—"}</td>
+        <td>${tipo}</td>
+        <td>${situacao}</td>
+        <td>${dtSituacao}</td>
+        <td>${btn}</td>
+      `;
+      el.tbodyTratamentoTabela.appendChild(tr);
+    });
+  }
+  if(el.treatmentTableInfo){
+    if(total){
+      const exibindo=paginaItens.length?`${inicio+1} - ${inicio+paginaItens.length}`:`0 - 0`;
+      el.treatmentTableInfo.textContent=`Exibindo ${exibindo} de ${total} planos.`;
+    }else{
+      el.treatmentTableInfo.textContent="Nenhum plano encontrado.";
+    }
+  }
+  if(el.treatmentTablePageLabel){
+    const paginaAtual=total? treatmentTablePage:1;
+    el.treatmentTablePageLabel.textContent=`pág. ${paginaAtual} de ${Math.max(1,totalPaginas)}`;
+  }
+  if(el.btnTreatmentTablePrev){
+    el.btnTreatmentTablePrev.disabled=!total||treatmentTablePage<=1;
+  }
+  if(el.btnTreatmentTableNext){
+    el.btnTreatmentTableNext.disabled=!total||treatmentTablePage>=totalPaginas;
+  }
 }
 
 function formatLogStatus(status){
@@ -1087,6 +1231,7 @@ function atualizarTratamentoUI(data){
   tratamentoDados=data;
   setTratamentoEstado(data.estado);
   renderTratamentoFila(data);
+  renderTratamentoTabela();
   renderTratamentoLogs();
 }
 
@@ -1337,6 +1482,37 @@ if(el.btnDownloadRescindidos){
   el.btnDownloadRescindidos.addEventListener("click",event=>{
     event.preventDefault();
     downloadRescindidos();
+  });
+}
+
+if(el.treatmentSearch){
+  el.treatmentSearch.addEventListener("input",event=>{
+    treatmentTableSearchTerm=event.target.value||"";
+    treatmentTablePage=1;
+    renderTratamentoTabela();
+  });
+}
+
+if(el.btnTreatmentTablePrev){
+  el.btnTreatmentTablePrev.addEventListener("click",event=>{
+    event.preventDefault();
+    if(treatmentTablePage>1){
+      treatmentTablePage-=1;
+      renderTratamentoTabela();
+    }
+  });
+}
+
+if(el.btnTreatmentTableNext){
+  el.btnTreatmentTableNext.addEventListener("click",event=>{
+    event.preventDefault();
+    const planos=tratamentoDados&&Array.isArray(tratamentoDados.planos)?tratamentoDados.planos:[];
+    const filtrados=filterTreatmentPlanos(planos);
+    const totalPaginas=Math.max(1,Math.ceil(filtrados.length/TREATMENT_TABLE_PAGE_SIZE));
+    if(treatmentTablePage<totalPaginas){
+      treatmentTablePage+=1;
+      renderTratamentoTabela();
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- Renomeei o card do tratamento para "PLANO EM EXECUÇÃO", ajustando layout e feedback visual do plano ativo.
- Criei o card "TABELA DE PLANOS" com busca, paginação de 10 itens e ação de download para cada plano em tratamento.
- Atualizei o JavaScript para filtrar, paginar e renderizar os dados da nova tabela mantendo o acompanhamento do plano em execução.

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1331931048323b3436215c7456b09