### PR TITLE
Remover log redundante na configuração de logging

### DIFF
--- a/sirep/infra/logging.py
+++ b/sirep/infra/logging.py
@@ -41,5 +41,3 @@ def setup_logging(level: str | None = None) -> None:
     # Integra loggers conhecidos
     for name in ("uvicorn", "uvicorn.error", "uvicorn.access", "asyncio"):
         logging.getLogger(name).setLevel(level)
-
-    logging.getLogger(__name__).info("logging configurado em %s (arquivo: %s)", level, LOG_PATH)


### PR DESCRIPTION
## Resumo
- remove o log informativo emitido durante a inicialização do módulo `sirep.infra.logging`

## Testes
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1c0275f508323afdf32031a3b8063