### PR TITLE
Refatorar etapas para usar helper de execução de job

### DIFF
--- a/sirep/services/base.py
+++ b/sirep/services/base.py
@@ -1,9 +1,13 @@
 from contextlib import contextmanager
-from typing import Iterable, Dict, Any
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional, Protocol, Union
+
 from sqlalchemy.orm import Session
-from sirep.infra.db import SessionLocal
-from sirep.infra.repositories import PlanRepository, EventRepository, JobRunRepository
+
 from sirep.domain.enums import Step
+from sirep.domain.models import JobRun
+from sirep.infra.db import SessionLocal
+from sirep.infra.repositories import EventRepository, JobRunRepository, PlanRepository
 
 @contextmanager
 def unit_of_work():
@@ -17,4 +21,91 @@ def unit_of_work():
     finally:
         db.close()
 
-class ServiceResult(Dict[str, Any]): ...
+class ServiceResult(Dict[str, Any]):
+    """Convenience mapping used by service layer helpers."""
+
+
+@dataclass
+class StepJobOutcome:
+    """Result returned by callbacks executed via :func:`run_step_job`."""
+
+    data: Optional[Dict[str, Any]] = None
+    status: str = "FINISHED"
+    info_update: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class StepJobContext:
+    """Context shared with step execution callbacks."""
+
+    db: Session
+    plans: PlanRepository
+    events: EventRepository
+    jobs: JobRunRepository
+    step: Step
+    job: Optional[JobRun] = None
+
+
+class StepJobCallback(Protocol):
+    def __call__(self, ctx: "StepJobContext") -> Union[StepJobOutcome, Dict[str, Any], None]:
+        """Execute the step-specific logic using the provided repositories."""
+
+
+def run_step_job(
+    *,
+    step: Step,
+    callback: StepJobCallback,
+    job_name: Optional[str] = None,
+    input_hash: Union[str, Callable[["StepJobContext"], str], None] = None,
+) -> ServiceResult:
+    """Execute a step job with shared boilerplate encapsulated.
+
+    Parameters
+    ----------
+    step:
+        Step being executed. Also used as default job name.
+    callback:
+        Function containing the specific logic for the step. It receives a
+        :class:`StepJobContext` with repositories and must return either a
+        :class:`StepJobOutcome`, a plain mapping with the result payload or
+        ``None``.
+    job_name:
+        Optional explicit name for the job. Defaults to ``step``.
+    input_hash:
+        Optional pre-computed hash or callable that receives a context (without
+        an active job) and returns the hash. Useful for hashing inputs fetched
+        from the database before starting the job.
+    """
+
+    with unit_of_work() as db:
+        plans = PlanRepository(db)
+        events = EventRepository(db)
+        jobs = JobRunRepository(db)
+        context = StepJobContext(db=db, plans=plans, events=events, jobs=jobs, step=step)
+
+        resolved_hash: Optional[str]
+        if callable(input_hash):
+            resolved_hash = input_hash(context)
+        else:
+            resolved_hash = input_hash
+
+        job = jobs.start(
+            job_name=job_name or step,
+            step=step,
+            input_hash=resolved_hash,
+        )
+        context.job = job
+
+        outcome = callback(context)
+        if isinstance(outcome, StepJobOutcome):
+            payload = ServiceResult(outcome.data or {})
+            status = outcome.status
+            info_update = outcome.info_update
+        else:
+            payload = ServiceResult(outcome or {})  # type: ignore[arg-type]
+            status = "FINISHED"
+            info_update = None
+
+        jobs.finish(job.id, status=status, info_update=info_update)
+        payload["job_id"] = job.id
+        return payload

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -1,7 +1,10 @@
-import os
 import pytest
+
+from sirep.domain.enums import PlanStatus, Step
+from sirep.domain.models import JobRun
 from sirep.infra.db import SessionLocal, init_db
 from sirep.infra.repositories import JobRunRepository
+from sirep.services.base import StepJobOutcome, run_step_job
 
 @pytest.fixture(scope="module", autouse=True)
 def _setup_schema():
@@ -23,3 +26,34 @@ def test_jobrun_start_and_finish():
         jr2 = repo.finish(jr.id, status="OK", info_update={"b":2})
         db.commit()
     assert jr2.status == "OK"
+
+
+def test_run_step_job_helper_executes_callback():
+    numero = "HELPER001"
+
+    def _callback(ctx) -> StepJobOutcome:
+        plan = ctx.plans.upsert(numero, status=PlanStatus.NOVO)
+        ctx.events.log(plan.id, Step.ETAPA_1, "execucao helper")
+        return StepJobOutcome(
+            data={"numero": plan.numero_plano},
+            info_update={"summary": "done"},
+        )
+
+    result = run_step_job(
+        step=Step.ETAPA_1,
+        job_name="helper",
+        input_hash="hash-123",
+        callback=_callback,
+    )
+
+    assert result["job_id"] > 0
+    assert result["numero"] == numero
+
+    with SessionLocal() as db:
+        job = db.get(JobRun, result["job_id"])
+        assert job is not None
+        assert job.status == "FINISHED"
+        assert job.job_name == "helper"
+        assert job.step == Step.ETAPA_1
+        assert job.input_hash == "hash-123"
+        assert job.info is not None and job.info.get("summary") == "done"


### PR DESCRIPTION
## Summary
- adicionar helper `run_step_job` para encapsular unit_of_work, repositórios e lifecycle de jobs
- refatorar etapas 1, 2, 3, 4 e 7 para utilizar callbacks com o helper compartilhado
- atualizar testes do pipeline para cobrir o helper e manter o comportamento existente

## Testing
- pytest tests/test_pipeline_smoke.py
- pytest *(falha: dependência `httpx` ausente no ambiente de testes)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c97a85b083239817463c7b7ae000