### PR TITLE
Refatora loop assíncrono dos serviços

### DIFF
--- a/sirep/app/async_loop.py
+++ b/sirep/app/async_loop.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Callable, Optional
+
+
+class AsyncLoopMixin:
+    """Utilitário compartilhado para serviços que usam loop assíncrono dedicado."""
+
+    _ASYNC_LOOP_THREAD_NAME: Optional[str] = None
+
+    def __init__(self) -> None:
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._loop_thread: Optional[threading.Thread] = None
+        self._loop_ready = threading.Event()
+
+    @staticmethod
+    async def _call_sync(func: Callable[[], None]) -> None:
+        func()
+
+    def _loop_thread_name(self) -> str:
+        if self._ASYNC_LOOP_THREAD_NAME:
+            return self._ASYNC_LOOP_THREAD_NAME
+        return f"{self.__class__.__name__.lower()}-loop"
+
+    def _on_loop_ready(self, loop: asyncio.AbstractEventLoop) -> None:  # pragma: no cover - hook
+        """Gancho executado quando o loop assíncrono está pronto."""
+
+    def _ensure_loop(self) -> asyncio.AbstractEventLoop:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is not None:
+            self._loop = loop
+            self._loop_ready.set()
+            self._on_loop_ready(loop)
+            return loop
+
+        existing = self._loop
+        if existing and existing.is_running():
+            self._loop_ready.set()
+            self._run_on_loop(lambda: self._on_loop_ready(existing), loop=existing, wait=True)
+            return existing
+
+        loop = asyncio.new_event_loop()
+        self._loop = loop
+        self._loop_ready.clear()
+
+        def runner() -> None:
+            asyncio.set_event_loop(loop)
+            try:
+                self._on_loop_ready(loop)
+            finally:
+                self._loop_ready.set()
+            loop.run_forever()
+
+        thread = threading.Thread(
+            target=runner,
+            name=self._loop_thread_name(),
+            daemon=True,
+        )
+        self._loop_thread = thread
+        thread.start()
+        self._loop_ready.wait()
+        return loop
+
+    def _run_on_loop(
+        self,
+        func: Callable[[], None],
+        *,
+        wait: bool = False,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+    ) -> None:
+        target = loop or self._loop
+        if target is None:
+            return
+
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+
+        if running is target:
+            func()
+            return
+
+        fut = asyncio.run_coroutine_threadsafe(self._call_sync(func), target)
+        if wait:
+            fut.result()

--- a/tests/test_captura_service.py
+++ b/tests/test_captura_service.py
@@ -29,6 +29,8 @@ def test_pausar_pos_conclusao_permite_reiniciar(monkeypatch):
     monkeypatch.setattr(CapturaService, "_sleep_with_pause", _sleep_rapido, raising=False)
 
     service.iniciar()
+    assert service._loop is not None
+    assert service._loop_thread is not None
     _esperar_estado(service, "concluido")
     assert service.status().estado == "concluido"
 

--- a/tests/test_tratamentos_endpoints.py
+++ b/tests/test_tratamentos_endpoints.py
@@ -142,6 +142,7 @@ def test_tratamento_continuar_apos_restaurar(monkeypatch):
     service = TratamentoService()
     created = service.migrar_planos()
     assert created
+    assert service._queue is not None
     service.iniciar()
     time.sleep(0.1)
     service.pausar()
@@ -151,6 +152,7 @@ def test_tratamento_continuar_apos_restaurar(monkeypatch):
     status = novo_service.status()
     assert status["estado"] == "pausado"
     assert status["planos"]
+    assert novo_service._queue is not None
 
     novo_service.continuar()
     deadline = time.time() + 2
@@ -187,6 +189,7 @@ def test_migrar_nao_inicia_sem_iniciar(monkeypatch):
     service = TratamentoService()
     first_ids = service.migrar_planos()
     assert first_ids
+    assert service._queue is not None
     service.iniciar()
 
     deadline = time.time() + 2


### PR DESCRIPTION
## Summary
- extrai AsyncLoopMixin para centralizar criação/uso de loops assíncronos com ganchos configuráveis
- atualiza CapturaService e TratamentoService para reutilizar o mixin preservando suas regras específicas
- ajusta testes de captura e tratamento para validar a inicialização de loop/fila após a refatoração

## Testing
- pytest *(falha: dependência `httpx` ausente no ambiente de testes)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c9796ac8832394e3a59977530164