### PR TITLE
Ajusta painel de fila e cores do resumo de tratamento

### DIFF
--- a/sirep/ui/css/styles.css
+++ b/sirep/ui/css/styles.css
@@ -133,6 +133,9 @@
     #treatmentQueueTable th{font-size:12px;color:#4b5563;font-weight:700;letter-spacing:.3px}
     #treatmentQueueTable tbody tr:last-child td{border-bottom:0}
     .queue-column{height:auto}
+    .treatment-queue-content{display:flex;gap:16px;align-items:stretch;flex-wrap:wrap}
+    .treatment-queue-content .treatment-queue-panel{flex:1 1 420px;min-width:0}
+    .treatment-queue-content .treatment-rescindidos{flex:1 1 220px;max-width:260px}
     .queue-column .treatment-queue-scroll{flex:0 1 auto;max-height:240px;overflow:auto;padding-right:4px;scrollbar-width:thin;scrollbar-color:rgba(17,24,39,.35) transparent}
     .queue-column .treatment-queue-scroll table{margin-bottom:0}
     .queue-column .treatment-queue-scroll::-webkit-scrollbar{width:8px}
@@ -147,6 +150,9 @@
     .treatment-rescindidos{border:1px solid var(--line);border-radius:12px;padding:16px;background:#f9fafb;display:flex;flex-direction:column;gap:12px}
     .rescindidos-metrics{display:flex;flex-direction:column;gap:12px}
     .rescindidos-metric{display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:14px}
+    .rescindidos-metric.queue .rescindidos-label,.rescindidos-metric.queue .rescindidos-value{color:#b45309}
+    .rescindidos-metric.rescindidos .rescindidos-label,.rescindidos-metric.rescindidos .rescindidos-value{color:#047857}
+    .rescindidos-metric.remaining .rescindidos-label,.rescindidos-metric.remaining .rescindidos-value{color:#b91c1c}
     .rescindidos-label{font-size:12px;font-weight:600;letter-spacing:.3px;color:var(--muted);text-transform:uppercase}
     .rescindidos-value{font-size:24px;font-weight:700;color:#111}
     .rescindidos-value.highlight{color:var(--accent)}

--- a/sirep/ui/index.html
+++ b/sirep/ui/index.html
@@ -173,75 +173,45 @@
           <div class="treatment-column queue-column" aria-live="polite">
             <h3>PLANO EM EXECUÇÃO</h3>
             <div class="muted">Enquanto um plano estiver em tratamento os demais aguardam.</div>
-            <div
-              class="subtabs treatment-queue-tabs"
-              role="tablist"
-              aria-label="Opções de visualização do plano em execução"
-            >
-              <span
-                class="subtab active"
-                id="treatmentQueueTabFila"
-                role="tab"
-                data-view="queue"
-                aria-selected="true"
-                aria-controls="treatmentQueuePanel"
-                tabindex="0"
-              >Fila</span>
-              <span
-                class="subtab"
-                id="treatmentQueueTabRescindidos"
-                role="tab"
-                data-view="rescindidos"
-                aria-selected="false"
-                aria-controls="treatmentRescindidosPanel"
-                tabindex="-1"
-              >Rescindidos</span>
-            </div>
-            <div
-              id="treatmentQueuePanel"
-              class="treatment-queue-panel"
-              role="tabpanel"
-              aria-labelledby="treatmentQueueTabFila"
-            >
-              <div class="treatment-queue-scroll" role="region" aria-label="Plano em execução">
-                <table id="treatmentQueueTable" aria-label="Plano em execução">
-                  <thead>
-                    <tr>
-                      <th scope="col">PLANO</th>
-                      <th scope="col">CNPJ</th>
-                      <th scope="col">RAZÃO SOCIAL</th>
-                      <th scope="col">STATUS</th>
-                      <th scope="col">ETAPA ATUAL</th>
-                    </tr>
-                  </thead>
-                  <tbody id="tbodyTratamentoFila"></tbody>
-                </table>
-                <div id="tratamentoEmpty" class="treatment-empty" hidden>Nenhum plano em execução no momento.</div>
-              </div>
-            </div>
-            <div
-              id="treatmentRescindidosPanel"
-              class="treatment-rescindidos"
-              role="tabpanel"
-              aria-labelledby="treatmentQueueTabRescindidos"
-              aria-live="polite"
-              hidden
-            >
-              <div class="rescindidos-metrics">
-                <div class="rescindidos-metric">
-                  <span class="rescindidos-label">Planos na fila</span>
-                  <span class="rescindidos-value" id="treatmentQueueCount">0</span>
-                </div>
-                <div class="rescindidos-metric">
-                  <span class="rescindidos-label">Rescindidos</span>
-                  <span class="rescindidos-value highlight" id="treatmentRescindidosCount">0</span>
-                </div>
-                <div class="rescindidos-metric" id="treatmentRescindidosRemaining" hidden>
-                  <span class="rescindidos-label">Falta</span>
-                  <span class="rescindidos-value" id="treatmentRescindidosRemainingValue">0</span>
+            <div class="treatment-queue-content">
+              <div id="treatmentQueuePanel" class="treatment-queue-panel">
+                <div class="treatment-queue-scroll" role="region" aria-label="Plano em execução">
+                  <table id="treatmentQueueTable" aria-label="Plano em execução">
+                    <thead>
+                      <tr>
+                        <th scope="col">PLANO</th>
+                        <th scope="col">CNPJ</th>
+                        <th scope="col">RAZÃO SOCIAL</th>
+                        <th scope="col">STATUS</th>
+                        <th scope="col">ETAPA ATUAL</th>
+                      </tr>
+                    </thead>
+                    <tbody id="tbodyTratamentoFila"></tbody>
+                  </table>
+                  <div id="tratamentoEmpty" class="treatment-empty" hidden>Nenhum plano em execução no momento.</div>
                 </div>
               </div>
-              <p class="muted rescindidos-hint">Os números são atualizados automaticamente conforme o tratamento avança.</p>
+              <aside
+                id="treatmentRescindidosPanel"
+                class="treatment-rescindidos"
+                aria-live="polite"
+              >
+                <div class="rescindidos-metrics">
+                  <div class="rescindidos-metric queue">
+                    <span class="rescindidos-label">Planos na fila</span>
+                    <span class="rescindidos-value" id="treatmentQueueCount">0</span>
+                  </div>
+                  <div class="rescindidos-metric rescindidos">
+                    <span class="rescindidos-label">Rescindidos</span>
+                    <span class="rescindidos-value" id="treatmentRescindidosCount">0</span>
+                  </div>
+                  <div class="rescindidos-metric remaining" id="treatmentRescindidosRemaining" hidden>
+                    <span class="rescindidos-label">Falta</span>
+                    <span class="rescindidos-value" id="treatmentRescindidosRemainingValue">0</span>
+                  </div>
+                </div>
+                <p class="muted rescindidos-hint">Os números são atualizados automaticamente conforme o tratamento avança.</p>
+              </aside>
             </div>
           </div>
 

--- a/sirep/ui/js/tratamento.js
+++ b/sirep/ui/js/tratamento.js
@@ -138,33 +138,29 @@
       return;
     }
 
-    const nextView = view === 'rescindidos' ? 'rescindidos' : 'queue';
-    state.queueView = nextView;
-    const isQueue = nextView === 'queue';
+    state.queueView = 'queue';
 
     if (el.treatmentQueueTabFila) {
-      el.treatmentQueueTabFila.classList.toggle('active', isQueue);
-      el.treatmentQueueTabFila.setAttribute('aria-selected', isQueue ? 'true' : 'false');
-      el.treatmentQueueTabFila.setAttribute('tabindex', isQueue ? '0' : '-1');
+      el.treatmentQueueTabFila.classList.add('active');
+      el.treatmentQueueTabFila.setAttribute('aria-selected', 'true');
+      el.treatmentQueueTabFila.setAttribute('tabindex', '0');
     }
 
     if (el.treatmentQueueTabRescindidos) {
-      el.treatmentQueueTabRescindidos.classList.toggle('active', !isQueue);
-      el.treatmentQueueTabRescindidos.setAttribute('aria-selected', !isQueue ? 'true' : 'false');
-      el.treatmentQueueTabRescindidos.setAttribute('tabindex', !isQueue ? '0' : '-1');
+      el.treatmentQueueTabRescindidos.classList.remove('active');
+      el.treatmentQueueTabRescindidos.setAttribute('aria-selected', 'false');
+      el.treatmentQueueTabRescindidos.setAttribute('tabindex', '-1');
     }
 
     if (el.treatmentQueuePanel) {
-      el.treatmentQueuePanel.hidden = !isQueue;
+      el.treatmentQueuePanel.hidden = false;
     }
 
     if (el.treatmentRescindidosPanel) {
-      el.treatmentRescindidosPanel.hidden = isQueue;
+      el.treatmentRescindidosPanel.hidden = false;
     }
 
-    if (!isQueue) {
-      updateRescindidosResumo(state.dados || { fila: [], planos: [] });
-    }
+    updateRescindidosResumo(state.dados || { fila: [], planos: [] });
   }
 
   function filterTreatmentPlanos(planos) {


### PR DESCRIPTION
## Summary
- reposiciona o painel de resumo de fila ao lado da tabela do plano em execução no tratamento
- aplica cores distintas para "Planos na fila", "Rescindidos" e "Falta" conforme solicitado
- mantém o painel de resumo sempre visível e sincronizado com os dados carregados

## Testing
- pytest *(falha: ambiente sem dependência httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d9b60aa4832382a7e230d84ed1a0