### PR TITLE
Ajusta interação do cabeçalho da Janela de Eventos

### DIFF
--- a/sirep/ui/css/styles.css
+++ b/sirep/ui/css/styles.css
@@ -50,11 +50,11 @@
     .logs-card{margin-top:16px;border-radius:14px;border:1px solid var(--line);overflow:hidden}
     .logs-header{
       display:flex;align-items:center;justify-content:space-between;
-      padding:10px 12px;background:#fff;cursor:pointer;user-select:none;
+      padding:10px 12px;background:#fff;user-select:none;
       border-bottom:1px solid var(--line)
     }
     .logs-header:focus{outline:2px solid rgba(16,140,188,.25);outline-offset:2px}
-    .logs-title{display:flex;align-items:center;gap:8px;font-weight:800;color:var(--text)}
+    .logs-title{display:flex;align-items:center;gap:8px;font-weight:800;color:var(--text);cursor:pointer}
     .logs-title .caret{display:inline-block;transition:transform .18s ease;transform-origin:center}
     .logs-header[aria-expanded="true"] .caret{transform:rotate(90deg)}
 

--- a/sirep/ui/js/logs.js
+++ b/sirep/ui/js/logs.js
@@ -167,16 +167,28 @@
       return;
     }
 
-    const toggle = (event) => {
+    const handleClick = (event) => {
+      if (!(event.target instanceof Element)) {
+        return;
+      }
+      const title = event.target.closest('.logs-title');
+      if (!title || !el.logsHeader.contains(title)) {
+        return;
+      }
+
       event.preventDefault();
       setLogsOpen(!state.logsOpen);
     };
-    el.logsHeader.addEventListener('click', toggle);
-    el.logsHeader.addEventListener('keydown', (event) => {
+
+    const handleKeydown = (event) => {
       if (event.key === 'Enter' || event.key === ' ') {
-        toggle(event);
+        event.preventDefault();
+        setLogsOpen(!state.logsOpen);
       }
-    });
+    };
+
+    el.logsHeader.addEventListener('click', handleClick);
+    el.logsHeader.addEventListener('keydown', handleKeydown);
   }
 
   function attachTreatmentLogsToggle() {
@@ -184,17 +196,28 @@
       return;
     }
 
-    const toggle = (event) => {
+    const handleClick = (event) => {
+      if (!(event.target instanceof Element)) {
+        return;
+      }
+      const title = event.target.closest('.logs-title');
+      if (!title || !el.treatmentLogsHeader.contains(title)) {
+        return;
+      }
+
       event.preventDefault();
       setTreatmentLogsOpen(!state.treatmentLogsOpen);
     };
 
-    el.treatmentLogsHeader.addEventListener('click', toggle);
-    el.treatmentLogsHeader.addEventListener('keydown', (event) => {
+    const handleKeydown = (event) => {
       if (event.key === 'Enter' || event.key === ' ') {
-        toggle(event);
+        event.preventDefault();
+        setTreatmentLogsOpen(!state.treatmentLogsOpen);
       }
-    });
+    };
+
+    el.treatmentLogsHeader.addEventListener('click', handleClick);
+    el.treatmentLogsHeader.addEventListener('keydown', handleKeydown);
   }
 
   function resolveInterval(fromInput, toInput) {


### PR DESCRIPTION
## Resumo
- Restringe o toggle das janelas de eventos para cliques apenas no título, evitando que os campos de data fechem a janela
- Atualiza o cursor para indicar que somente o título é clicável

## Testes
- Não aplicável (alterações no frontend estático)


------
https://chatgpt.com/codex/tasks/task_e_68d1e0ac8b388323b5889e6eaae4e5cd