### PR TITLE
Ajusta exibição dos CNPJs no tratamento

### DIFF
--- a/sirep/ui/css/styles.css
+++ b/sirep/ui/css/styles.css
@@ -46,6 +46,7 @@
     #btnContinuar:not(.primary),#btnTratamentoContinuar:not(.primary){background:#f3f4f6;color:var(--muted);border-color:#d1d5db}
     button:disabled{opacity:.5;cursor:not-allowed}
     .muted{color:var(--muted);font-size:12px}
+    .cnpj-cell{display:inline-flex;align-items:center;gap:4px}
     .row{display:flex;gap:14px;flex-wrap:wrap;align-items:center}
     .progress{height:10px;background:#f3f4f6;border:1px solid var(--line);border-radius:999px;overflow:hidden;width:100%;min-width:220px;flex:1 1 auto}
     .progress>div{height:100%;background:linear-gradient(90deg,var(--prog-a),var(--prog-b));position:relative;transition:width .2s ease}


### PR DESCRIPTION
## Summary
- normaliza a renderização dos CNPJs para privilegiar o principal e ocultar os demais
- utiliza o CNPJ principal informado pela API tanto na fila quanto na tabela de planos
- adiciona um contêiner com espaçamento dedicado para o resumo dos CNPJs

## Testing
- pytest *(falha: dependência httpx ausente no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68d3bc3630d083239fc009492480ac65