### PR TITLE
Integrate secure login password with gestão base

### DIFF
--- a/sirep/domain/schemas.py
+++ b/sirep/domain/schemas.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 from typing import Any, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .enums import PlanStatus
 
@@ -73,4 +73,8 @@ class PipelineRunItem(BaseModel):
 class PipelineRunResponse(BaseModel):
     count: int
     items: list[PipelineRunItem]
+
+
+class GestaoBasePasswordIn(BaseModel):
+    password: str = Field(..., repr=False, description="Senha utilizada na Gestão da Base.")
 

--- a/sirep/infra/runtime_credentials.py
+++ b/sirep/infra/runtime_credentials.py
@@ -1,0 +1,75 @@
+"""Infraestrutura simples para armazenar segredos de forma volátil."""
+
+from __future__ import annotations
+
+from threading import RLock
+from typing import Optional
+
+
+class _RuntimeCredentialsStore:
+    """Armazena segredos efêmeros na memória do processo."""
+
+    _GESTAO_BASE_PASSWORD_KEY = "gestao_base_password"
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._secrets: dict[str, str] = {}
+
+    def set_secret(self, key: str, value: Optional[str]) -> None:
+        """Define ou limpa o valor associado a ``key``."""
+
+        with self._lock:
+            if value is None or value == "":
+                self._secrets.pop(key, None)
+            else:
+                self._secrets[key] = value
+
+    def get_secret(self, key: str) -> Optional[str]:
+        """Recupera o valor armazenado para ``key`` se houver."""
+
+        with self._lock:
+            return self._secrets.get(key)
+
+    def clear_all(self) -> None:
+        """Remove todos os segredos armazenados."""
+
+        with self._lock:
+            self._secrets.clear()
+
+    # -- atalhos específicos para Gestão da Base ---------------------------------
+
+    def set_gestao_base_password(self, password: Optional[str]) -> None:
+        self.set_secret(self._GESTAO_BASE_PASSWORD_KEY, password)
+
+    def get_gestao_base_password(self) -> Optional[str]:
+        return self.get_secret(self._GESTAO_BASE_PASSWORD_KEY)
+
+    def clear_gestao_base_password(self) -> None:
+        self.set_secret(self._GESTAO_BASE_PASSWORD_KEY, None)
+
+
+_STORE = _RuntimeCredentialsStore()
+
+
+def set_gestao_base_password(password: Optional[str]) -> None:
+    """Guarda a senha da Gestão da Base em memória."""
+
+    _STORE.set_gestao_base_password(password)
+
+
+def get_gestao_base_password() -> Optional[str]:
+    """Retorna a senha atualmente armazenada para Gestão da Base."""
+
+    return _STORE.get_gestao_base_password()
+
+
+def clear_gestao_base_password() -> None:
+    """Remove a senha armazenada da Gestão da Base."""
+
+    _STORE.clear_gestao_base_password()
+
+
+def clear_all_credentials() -> None:
+    """Remove todos os segredos voláteis."""
+
+    _STORE.clear_all()

--- a/sirep/services/gestao_base.py
+++ b/sirep/services/gestao_base.py
@@ -14,6 +14,7 @@ from typing import Callable, Iterable, Iterator, List, Optional, Protocol, Tuple
 
 from sirep.domain.enums import PlanStatus, Step
 from sirep.infra.config import settings
+from sirep.infra.runtime_credentials import get_gestao_base_password
 from sirep.services.base import ServiceResult, StepJobContext, StepJobOutcome, run_step_job
 
 logger = logging.getLogger(__name__)
@@ -523,16 +524,31 @@ class GestaoBaseService:
     def __init__(self, portal_provider: Optional[Callable[[], List[dict]]] = None) -> None:
         self.portal_provider = portal_provider or (portal_po_provider if not settings.DRY_RUN else None)
 
-    def _collector(self, senha: Optional[str]) -> GestaoBaseCollector:
-        if settings.DRY_RUN or senha is None:
+    def _collector(self, senha: Optional[str]) -> Optional[GestaoBaseCollector]:
+        if settings.DRY_RUN:
             return DryRunCollector()
-        return TerminalCollector(senha, self.portal_provider)
+
+        resolved = senha or get_gestao_base_password()
+        if not resolved:
+            logger.warning(
+                "Senha da Gestão da Base não disponível; execução será interrompida."
+            )
+            return None
+
+        return TerminalCollector(resolved, self.portal_provider)
 
     def execute(self, senha: Optional[str] = None) -> ServiceResult:
         """Executa a captura de Gestão da Base e persiste os registros."""
 
         def _run(context: StepJobContext) -> StepJobOutcome:
             collector = self._collector(senha)
+            if collector is None:
+                return StepJobOutcome(
+                    data={"error": "Senha da Gestão da Base não configurada."},
+                    status="FAILED",
+                    info_update={"summary": "Execução bloqueada por falta de senha"},
+                )
+
             data = collector.collect()
             resultado = _persist_rows(context, data)
             summary = f"{resultado['importados']} planos"

--- a/sirep/ui/js/app.js
+++ b/sirep/ui/js/app.js
@@ -189,12 +189,20 @@
     }
   }
 
-  function handleLogout() {
+  async function handleLogout() {
     if (Auth && typeof Auth.clearCredentials === 'function') {
       try {
         Auth.clearCredentials();
       } catch (error) {
         console.warn('Falha ao limpar credenciais ao encerrar sessão.', error);
+      }
+    }
+
+    if (typeof fetch === 'function') {
+      try {
+        await fetch('/session/gestao-base/password', { method: 'DELETE' });
+      } catch (error) {
+        console.warn('Falha ao limpar a senha de Gestão da Base.', error);
       }
     }
 
@@ -240,7 +248,10 @@
     if (logoutButton) {
       logoutButton.addEventListener('click', (event) => {
         event.preventDefault();
-        handleLogout();
+        Promise.resolve(handleLogout()).catch((error) => {
+          console.error('Falha ao encerrar sessão.', error);
+          redirectToLogin();
+        });
       });
     }
 

--- a/tests/test_runtime_credentials.py
+++ b/tests/test_runtime_credentials.py
@@ -1,0 +1,41 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from sirep.app.api import app
+from sirep.infra.runtime_credentials import (
+    clear_all_credentials,
+    get_gestao_base_password,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_credentials():
+    clear_all_credentials()
+    yield
+    clear_all_credentials()
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_store_and_clear_gestao_password(client: TestClient):
+    response = client.post(
+        "/session/gestao-base/password", json={"password": "SenhaSecreta!"}
+    )
+    assert response.status_code == 204
+    assert get_gestao_base_password() == "SenhaSecreta!"
+
+    response = client.delete("/session/gestao-base/password")
+    assert response.status_code == 204
+    assert get_gestao_base_password() is None
+
+
+def test_store_gestao_password_rejects_blank(client: TestClient):
+    response = client.post("/session/gestao-base/password", json={"password": "   "})
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload.get("detail") == "Senha obrigatória."
+    assert get_gestao_base_password() is None


### PR DESCRIPTION
## Summary
- add an in-memory runtime credential store to keep the Gestão da Base password captured at login
- expose endpoints to persist and clear the stored password and surface it in the service execution flow
- sync the login/logout UI with the new endpoints and cover the behaviour with API tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d3cb72700883238c0075f0a714018b