### PR TITLE
Fix duplicate tipo keyword in sample data

### DIFF
--- a/sirep/services/gestao_base.py
+++ b/sirep/services/gestao_base.py
@@ -588,7 +588,6 @@ def _sample_data() -> GestaoBaseData:
             numero="1234567890",
             dt_propost="01/02/2024",
             tipo="PR1",
-            tipo="ADM",
             situac="P.RESC.",
             resoluc="123/45",
             razao_social="Empresa Alfa Ltda",


### PR DESCRIPTION
## Summary
- remove the duplicate `tipo` argument from the `_sample_data` helper to prevent a syntax error during imports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3ce668b648323b0cfe5a3ef4b9ea1