### PR TITLE
Improve capture progress tracking and database resilience

### DIFF
--- a/sirep/app/api.py
+++ b/sirep/app/api.py
@@ -302,6 +302,7 @@ async def captura_status():
             for h in st.historico
         ],
         "ultima_atualizacao": st.ultima_atualizacao,
+        "progresso_etapa": st.progress_stage,
         "ocorrencias_total": ocorrencias_total,
         "total": total,
         "total_passiveis": total_passiveis,


### PR DESCRIPTION
## Summary
- add a progress override channel to `CapturaService` so the real Gestão da Base run updates the status bar and history in real time
- expose the current capture stage in `/captura/status` and implement resilient log persistence with retries when SQLite reports `database is locked`
- extend `GestaoBaseService` with progress callbacks, hook them into collectors/persistence, and cover the behaviour with a regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4194ad3cc832391c2a2df378f0197