### PR TITLE
feat: preparar infraestrutura para PostgreSQL

### DIFF
--- a/sirep/infra/config.py
+++ b/sirep/infra/config.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Literal
 
+from pydantic import Field
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
@@ -11,6 +13,11 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(env_file=".env", env_prefix="SIREP_", extra="ignore")
     DB_URL: str = "sqlite:///./sirep.db"
+    DB_ECHO: bool = False
+    DB_POOL_SIZE: int | None = Field(default=None, ge=1)
+    DB_MAX_OVERFLOW: int | None = Field(default=None, ge=0)
+    DB_POOL_TIMEOUT: int | None = Field(default=None, ge=1)
+    DB_POOL_RECYCLE: int | None = Field(default=None, ge=1)
     RUNTIME_ENV: Literal["dev", "prod", "test"] = "dev"
     DRY_RUN: bool = True  # evita efeitos colaterais em stubs
     LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"

--- a/sirep/infra/db.py
+++ b/sirep/infra/db.py
@@ -2,18 +2,61 @@
 
 from __future__ import annotations
 
-from sqlalchemy import create_engine, text
-from sqlalchemy.exc import OperationalError
+from collections.abc import Mapping
+from typing import Any
+
+from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker
 
 from sirep.infra.config import settings
 
 
+SQLITE_SCHEME_PREFIX = "sqlite:///"
+
+
+def _build_engine_options() -> dict[str, Any]:
+    options: dict[str, Any] = {"future": True, "pool_pre_ping": True}
+
+    if settings.DB_ECHO:
+        options["echo"] = True
+
+    if settings.DB_POOL_SIZE is not None:
+        options["pool_size"] = settings.DB_POOL_SIZE
+
+    if settings.DB_MAX_OVERFLOW is not None:
+        options["max_overflow"] = settings.DB_MAX_OVERFLOW
+
+    if settings.DB_POOL_TIMEOUT is not None:
+        options["pool_timeout"] = settings.DB_POOL_TIMEOUT
+
+    if settings.DB_POOL_RECYCLE is not None:
+        options["pool_recycle"] = settings.DB_POOL_RECYCLE
+
+    if is_sqlite_url(settings.DB_URL):
+        connect_args: dict[str, Any]
+        existing = options.get("connect_args")
+        if isinstance(existing, Mapping):
+            connect_args = dict(existing)
+        else:
+            connect_args = {}
+        connect_args.setdefault("check_same_thread", False)
+        options["connect_args"] = connect_args
+
+    return options
+
+
+def is_sqlite_url(url: str) -> bool:
+    """Return ``True`` if the database URL points to a SQLite database."""
+
+    return url.startswith(SQLITE_SCHEME_PREFIX)
+
+
 def get_engine() -> Engine:
     """Create a SQLAlchemy engine configured with the application settings."""
 
-    return create_engine(settings.DB_URL, future=True)
+    return create_engine(settings.DB_URL, **_build_engine_options())
 
 
 _engine = get_engine()
@@ -28,13 +71,16 @@ SessionLocal = sessionmaker(
 
 
 def init_db() -> None:
-    """Create database tables and backfill missing columns for legacy databases."""
+    """Create database tables and apply legacy migrations when needed."""
 
     # importa Base aqui para evitar import circular
     from sirep.domain.models import Base
 
     Base.metadata.create_all(bind=_engine)
+    _apply_legacy_plan_patches()
 
+
+def _apply_legacy_plan_patches() -> None:
     legacy_columns = {
         "razao_social": "ALTER TABLE plans ADD COLUMN razao_social VARCHAR(255)",
         "data_rescisao": "ALTER TABLE plans ADD COLUMN data_rescisao DATE",
@@ -49,8 +95,11 @@ def init_db() -> None:
     columns_to_drop = ("tipo_parcelamento", "saldo_total")
 
     with _engine.begin() as conn:
-        info = conn.execute(text("PRAGMA table_info(plans)")).fetchall()
-        existing = {row[1] for row in info}
+        inspector = inspect(conn)
+        if not inspector.has_table("plans"):
+            return
+
+        existing = {column["name"] for column in inspector.get_columns("plans")}
 
         for column, ddl in legacy_columns.items():
             if column not in existing:
@@ -60,5 +109,7 @@ def init_db() -> None:
             if column in existing:
                 try:
                     conn.execute(text(f"ALTER TABLE plans DROP COLUMN {column}"))
-                except OperationalError:
-                    pass
+                except OperationalError as exc:  # pragma: no cover - sqlite compat
+                    if is_sqlite_url(settings.DB_URL):
+                        continue
+                    raise exc

--- a/sirep/pyproject.toml
+++ b/sirep/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
   "uvicorn>=0.30.0",
   "pydantic>=2.8.0",
   "SQLAlchemy>=2.0.32",
+  "psycopg[binary]>=3.1.12",
   "pydantic-settings>=2.4.0",
   "python-dotenv>=1.0.1",
   "tzdata>=2024.1",

--- a/sirep/scripts/reset_db.py
+++ b/sirep/scripts/reset_db.py
@@ -1,45 +1,39 @@
+"""Utility script to reset the configured database."""
+
 from __future__ import annotations
-
-import os
-from sirep.infra.config import settings
-from sirep.infra.db import get_engine
-
-def is_sqlite_file(url: str) -> str | None:
-    if url.startswith("sqlite:///"):
-        path = url.replace("sqlite:///", "", 1)
-        return os.path.abspath(path)
-    return None
-
-def main():
-    sqlite_path = is_sqlite_file(settings.DB_URL)
-    if sqlite_path:
-        if os.path.exists(sqlite_path):
-            os.remove(sqlite_path)
-            print(f"[reset-db] removido arquivo SQLite: {sqlite_path}")
-        else:
-            print(f"[reset-db] arquivo SQLite já não existe: {sqlite_path}")
-
 
 from pathlib import Path
 from typing import Final
 
 from sirep.infra.config import settings
-from sirep.infra.db import get_engine
+from sirep.infra.db import get_engine, is_sqlite_url
 
 
 SQLITE_PREFIX: Final[str] = "sqlite:///"
 
 
 def sqlite_path_from_url(url: str) -> Path | None:
-    """Return the path for SQLite URLs (``sqlite:///``) or ``None`` otherwise."""
+    """Return the local filesystem path for SQLite URLs."""
 
-    if not url.startswith(SQLITE_PREFIX):
+    if not is_sqlite_url(url):
         return None
+
     return Path(url.removeprefix(SQLITE_PREFIX)).expanduser().resolve()
 
 
+def remove_sqlite_file(path: Path) -> None:
+    """Remove the SQLite file if it exists, logging the action to stdout."""
+
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        print(f"[reset-db] arquivo SQLite já não existe: {path}")
+    else:
+        print(f"[reset-db] removido arquivo SQLite: {path}")
+
+
 def recreate_relational_schema() -> None:
-    """Drop and create all ORM metadata objects for non-SQLite databases."""
+    """Drop and recreate all ORM metadata objects for non-SQLite databases."""
 
     from sirep.domain.models import Base
 
@@ -47,23 +41,12 @@ def recreate_relational_schema() -> None:
     with engine.begin() as conn:
         Base.metadata.drop_all(bind=conn)
         Base.metadata.create_all(bind=conn)
+
     print("[reset-db] schema recriado no banco configurado.")
 
 
-def remove_sqlite_file(path: Path) -> None:
-    """Remove the SQLite file if it exists, reporting the action to stdout."""
-
-    try:
-        path.unlink()
-    except FileNotFoundError:
-        print(f"[reset-db] arquivo SQLite já não existe: {path}")
-
-    else:
-        print(f"[reset-db] removido arquivo SQLite: {path}")
-
-
 def main() -> None:
-    """Reset the configured database, handling SQLite files and other engines."""
+    """Reset the configured database depending on the configured URL."""
 
     sqlite_path = sqlite_path_from_url(settings.DB_URL)
     if sqlite_path is not None:


### PR DESCRIPTION
## Summary
- adicionar configurações de pool e echo para parametrizar o SQLAlchemy
- atualizar a criação do engine para funcionar tanto com SQLite quanto com PostgreSQL
- refatorar o reset_db para lidar com bancos relacionais e adicionar dependência do driver psycopg

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d454b1cd6c8323bb52fb612e5906aa