### PR TITLE
Registrar planos em ocorrências na captura real

### DIFF
--- a/sirep/infra/repositories.py
+++ b/sirep/infra/repositories.py
@@ -130,8 +130,8 @@ class OccurrenceRepository:
         numero_plano: str,
         situacao: str,
         cnpj: str,
-        tipo: str,
-        saldo: float,
+        tipo: Optional[str] = None,
+        saldo: Optional[float] = None,
         dt_situacao_atual: Optional[date] = None,
     ) -> DiscardedPlan:
         row = DiscardedPlan(


### PR DESCRIPTION
## Summary
- registra automaticamente as situações especiais da captura real na tabela de ocorrências
- permite persistir ocorrências com tipo/saldo opcionais
- cobre o novo fluxo com teste garantindo que apenas os planos esperados virem ocorrências

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d48a1b60c4832391e23d1323257e0a