### PR TITLE
Ajusta cálculo de dias em atraso e UI dinâmica

### DIFF
--- a/tests/test_gestao_base_service.py
+++ b/tests/test_gestao_base_service.py
@@ -240,17 +240,17 @@ def test_gestao_base_persiste_parcelas_e_dias_em_atraso(monkeypatch):
     with SessionLocal() as db:
         plan = db.query(Plan).filter_by(numero_plano="PLN_ATRASO").one()
 
-    assert plan.dias_em_atraso == 106
+    assert plan.dias_em_atraso == 137
     assert plan.parcelas_atraso is not None
     assert len(plan.parcelas_atraso) == 3
     parcelas = plan.parcelas_atraso
-    assert parcelas[0]["parcela"] == "101"
-    assert parcelas[0]["vencimento"] == "2024-08-01"
-    assert parcelas[0]["dias_em_atraso"] == 45
-    assert parcelas[1]["parcela"] == "102"
-    assert parcelas[1]["dias_em_atraso"] == 76
-    assert parcelas[2]["parcela"] == "103"
-    assert parcelas[2]["dias_em_atraso"] == 106
+    assert parcelas[0]["parcela"] == "104"
+    assert parcelas[0]["vencimento"] == "2024-05-01"
+    assert parcelas[1]["parcela"] == "103"
+    assert parcelas[1]["vencimento"] == "2024-06-01"
+    assert parcelas[2]["parcela"] == "102"
+    assert parcelas[2]["vencimento"] == "2024-07-01"
+    assert "dias_em_atraso" not in parcelas[0]
 
 
 def test_gestao_base_limpa_parcelas_em_atraso_quando_regulariza(monkeypatch):


### PR DESCRIPTION
## Summary
- simplifica o parse dos vencimentos para o formato DD/MM/AAAA e prioriza as parcelas mais antigas ao normalizar atrasos
- garante que o backend utilize apenas o cálculo baseado no dia atual ao persistir dias em atraso
- atualiza a UI para calcular dias em atraso dinamicamente e ajusta os testes do serviço da Gestão da Base

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d498ae68e483238989c1b6a6c213a8