### PR TITLE
Remove redundancies in tratamento service and job runner

### DIFF
--- a/sirep/app/tratamento.py
+++ b/sirep/app/tratamento.py
@@ -29,7 +29,6 @@ from sirep.domain.logs import (
 from sirep.shared.config import DATE_DISPLAY_FORMAT
 from sirep.shared.fakes import (
     TIPOS_PARCELAMENTO,
-    TIPOS_REPRESENTACAO,
     gerar_bases,
     gerar_cnpjs,
     gerar_periodo,

--- a/sirep/services/base.py
+++ b/sirep/services/base.py
@@ -93,7 +93,6 @@ def run_step_job(
             resolved_job_name: Optional[str] = job_name.name
         else:
             resolved_job_name = job_name
-        default_job_name = step.name if isinstance(step, Step) else str(step)
         final_job_name = resolved_job_name or step.name
         job = jobs.start(
             job_name=final_job_name,


### PR DESCRIPTION
## Summary
- remove the unused TIPOS_REPRESENTACAO import from the tratamento service module
- drop the unused default_job_name assignment in the shared job runner helper

## Testing
- ruff check sirep
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d49d8b358083238ea5d9b3b9d4089e