### PR TITLE
Ajusta resumo da captura de Gestão da Base

### DIFF
--- a/sirep/services/gestao_base.py
+++ b/sirep/services/gestao_base.py
@@ -898,7 +898,6 @@ class GestaoBaseService:
             data = collector.collect(progress_callback)
             resultado = _persist_rows(context, data, progress_callback)
             summary = _format_summary(resultado)
-            summary = f"{resultado['importados']} planos"
             return StepJobOutcome(data=resultado, info_update={"summary": summary})
 
         return run_step_job(step=Step.ETAPA_1, job_name=Step.ETAPA_1, callback=_run)


### PR DESCRIPTION
## Sumário
- garante que o serviço de Gestão da Base reutilize o texto completo produzido por `_format_summary`
- evita perder o detalhamento de planos novos/atualizados exibido para a interface

## Testes
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d4a315cbe88323a9a91c554b94fa2b