### PR TITLE
Fix plan queue status for pending treatments

### DIFF
--- a/sirep/app/tratamento.py
+++ b/sirep/app/tratamento.py
@@ -265,6 +265,11 @@ class TratamentoService(AsyncLoopMixin):
                     or situacao_status == PlanStatus.PASSIVEL_RESC
                 )
 
+                if should_queue and plan_status != PlanStatus.PASSIVEL_RESC:
+                    plan_status = PlanStatus.PASSIVEL_RESC
+                    plan.status = plan_status.value
+                    status_raw = plan.status
+
                 if plan_status == PlanStatus.RESCINDIDO:
                     treatment.status = "rescindido"
                     if plan.data_rescisao:
@@ -273,7 +278,7 @@ class TratamentoService(AsyncLoopMixin):
                     PlanStatus.LIQUIDADO,
                     PlanStatus.NAO_RESCINDIDO,
                     PlanStatus.ESPECIAL,
-                }:
+                } and not should_queue:
                     treatment.status = status_raw or plan.situacao_atual or "ignorado"
                 elif not should_queue:
                     treatment.status = status_raw or plan.situacao_atual or "ignorado"


### PR DESCRIPTION
## Summary
- keep queued treatment plans in pendente status even when existing plan status indicates finalization
- normalize queued plans by updating plan status to PASSIVEL_RESC when the current situacao requires treatment
- add regression test covering migration of plans with conflicting status and situacao

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4a66223c483238070af95bd3ec78b