### PR TITLE
feat(ui): redesign login experience for pipeline password capture

### DIFF
--- a/sirep/ui/css/styles.css
+++ b/sirep/ui/css/styles.css
@@ -2,23 +2,34 @@
     *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,Segoe UI,Roboto}
     header{position:sticky;top:0;z-index:10;background:linear-gradient(90deg,var(--hdr-a),var(--hdr-b),var(--hdr-c));color:#fff}
     .login-overlay{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:24px;background:linear-gradient(135deg,rgba(0,57,186,.88),rgba(16,140,188,.82));backdrop-filter:blur(6px);z-index:1200}
-    body.login-screen{min-height:100vh;display:flex;align-items:center;justify-content:center;margin:0;padding:24px;background:linear-gradient(135deg,rgba(0,57,186,.88),rgba(16,140,188,.82));color:var(--text)}
+    body.login-screen{min-height:100vh;display:flex;align-items:center;justify-content:center;margin:0;padding:24px;background:linear-gradient(135deg,rgba(0,57,186,.9),rgba(16,140,188,.85));color:var(--text)}
+    #loginOverlay{width:100%;display:flex;align-items:center;justify-content:center}
     .login-screen__content{width:100%;display:flex;align-items:center;justify-content:center}
-    .login-card{width:100%;max-width:360px;background:#fff;border-radius:18px;padding:32px 28px;box-shadow:0 28px 60px rgba(15,23,42,.25);display:flex;flex-direction:column;gap:18px}
-    .login-card h2{margin:0;font-size:22px;font-weight:800;color:var(--accent);text-align:center}
-    .login-description{margin:0;color:var(--muted);line-height:1.5;font-size:14px}
+    .login-card{width:100%;max-width:380px;background:#fff;border-radius:20px;padding:36px 32px;box-shadow:0 32px 70px rgba(15,23,42,.28);display:flex;flex-direction:column;gap:20px}
+    .login-card__header{display:flex;align-items:center;gap:16px}
+    .login-card__logo{width:64px;height:64px;border-radius:18px;background:linear-gradient(135deg,#0b5fa8,#49c3b6);display:inline-flex;align-items:center;justify-content:center;font-weight:800;font-size:26px;color:#fff;box-shadow:0 14px 30px rgba(11,95,168,.35)}
+    .login-card__logo span{display:inline-block;transform:translateY(2px)}
+    .login-card__eyebrow{margin:0;font-size:12px;letter-spacing:.14em;text-transform:uppercase;font-weight:700;color:var(--muted)}
+    .login-card__title{margin:4px 0 0;font-size:26px;font-weight:800;color:var(--accent)}
+    .login-description{margin:0;color:var(--muted);line-height:1.55;font-size:14px}
     .login-field{display:flex;flex-direction:column;gap:6px}
     .login-field label{font-weight:700;font-size:13px;color:var(--text)}
-    .login-field input{border:1px solid var(--line);border-radius:10px;padding:10px 12px;font:inherit;transition:border-color .2s ease,box-shadow .2s ease}
-    .login-field input.with-icon{padding-left:40px;background-repeat:no-repeat;background-position:12px center;background-size:18px 18px;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%236b7280' stroke-width='1.8'%3E%3Crect x='4.2' y='8.5' width='11.6' height='8.5' rx='2.2'/%3E%3Cpath d='M7.6 8.4V6.6a2.4 2.4 0 0 1 4.8 0v1.8'/%3E%3Ccircle cx='10' cy='12.2' r='1.3'/%3E%3Cpath d='M10 13.5v1.8'/%3E%3C/svg%3E")}
+    .login-field__control{position:relative;display:flex;align-items:center}
+    .login-field input{border:1px solid var(--line);border-radius:12px;padding:12px 14px;font:inherit;transition:border-color .2s ease,box-shadow .2s ease;width:100%}
+    .login-field--icon .login-field__icon{position:absolute;left:14px;display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;color:var(--muted)}
+    .login-field--icon input{padding-left:48px}
+    .login-field__icon svg{width:20px;height:20px;fill:currentColor}
     .login-field input:focus{outline:2px solid rgba(16,140,188,.25);outline-offset:2px}
+    .login-support{margin:0;font-size:12px;color:var(--muted)}
     .login-actions{display:flex;flex-direction:column;gap:12px}
     .login-submit{width:100%;font-size:15px;padding:12px 14px}
+    .login-help{font-size:12px;text-align:center;color:#0b5fa8;text-decoration:none;font-weight:700}
+    .login-help:hover,.login-help:focus-visible{text-decoration:underline;outline:none}
     .login-error{margin:0;font-size:12px;color:#b91c1c;font-weight:600}
-    .login-footer{margin-top:4px;text-align:center;color:var(--muted);font-size:12px;line-height:1.5}
+    .login-footer{margin-top:4px;text-align:center;color:var(--muted);font-size:12px;line-height:1.5;display:flex;flex-direction:column;gap:4px}
     .login-footer p{margin:0}
-    .login-footer p+p{margin-top:4px}
-    @media (max-width:520px){.login-card{padding:26px 20px}}
+    .login-footer p+p{margin-top:0}
+    @media (max-width:520px){.login-card{padding:30px 22px}}
     .top{display:flex;align-items:center;justify-content:center;padding:12px 16px;position:relative}
     .top h1{margin:0;font-size:18px;font-weight:800;letter-spacing:.5px}
     .top .icons{position:absolute;right:12px;display:flex;gap:12px;align-items:center}

--- a/sirep/ui/login.html
+++ b/sirep/ui/login.html
@@ -7,42 +7,75 @@
   <link rel="stylesheet" href="css/styles.css" />
 </head>
 <body class="login-screen">
-  <main class="login-screen__content" aria-labelledby="loginTitle">
-    <form id="loginForm" class="login-card" data-redirect="index.html" novalidate>
-      <h2 id="loginTitle">SIREP 2.0</h2>
-      <p class="login-description">Acesse com a mesma senha do Rede Caixa.</p>
-      <div class="login-field">
-        <label for="loginUser">Matrícula</label>
-        <input
-          type="text"
-          id="loginUser"
-          name="username"
-          autocomplete="username"
-          placeholder="C123456"
-          required
-        />
-      </div>
-      <div class="login-field">
-        <label for="loginPassword">Senha</label>
-        <input
-          type="password"
-          id="loginPassword"
-          name="password"
-          class="with-icon"
-          autocomplete="current-password"
-          placeholder="Digite sua senha"
-          required
-        />
-      </div>
-      <p id="loginError" class="login-error" role="alert" aria-live="assertive" hidden></p>
-      <div class="login-actions">
-        <button type="submit" id="loginSubmit" class="primary login-submit">Entrar</button>
-      </div>
-      <footer class="login-footer" aria-label="Informações institucionais">
-        <p>CEFGD/RJ – Recuperação de Débitos do FGTS Perante o Empregador</p>
-      </footer>
-    </form>
-  </main>
+  <div id="loginOverlay" class="login-screen__overlay" aria-hidden="false">
+    <main class="login-screen__content" aria-labelledby="loginTitle">
+      <form id="loginForm" class="login-card" data-redirect="index.html" novalidate>
+        <header class="login-card__header">
+          <div class="login-card__logo" aria-hidden="true">
+            <span>S</span>
+          </div>
+          <div>
+            <p class="login-card__eyebrow">Acesso restrito</p>
+            <h1 id="loginTitle" class="login-card__title">SIREP 2.0</h1>
+          </div>
+        </header>
+
+        <p class="login-description">Informe sua matrícula Rede Caixa para liberar a execução da Gestão da Base.</p>
+
+        <div class="login-field login-field--icon">
+          <label for="loginUser">Matrícula</label>
+          <div class="login-field__control">
+            <span class="login-field__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false" role="presentation">
+                <path d="M12 12.5a4.25 4.25 0 1 0 0-8.5 4.25 4.25 0 0 0 0 8.5Zm0 2.25c-3.93 0-7.25 2.28-7.25 5.2 0 .57.48 1.03 1.08 1.03h12.34c.6 0 1.08-.46 1.08-1.03 0-2.92-3.32-5.2-7.25-5.2Z"/>
+              </svg>
+            </span>
+            <input
+              type="text"
+              id="loginUser"
+              name="username"
+              autocomplete="username"
+              placeholder="C123456"
+              required
+            />
+          </div>
+        </div>
+
+        <div class="login-field login-field--icon">
+          <label for="loginPassword">Senha</label>
+          <div class="login-field__control">
+            <span class="login-field__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false" role="presentation">
+                <path d="M7.5 11V8.75a4.5 4.5 0 1 1 9 0V11H19a1 1 0 0 1 1 1v7.25a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V12a1 1 0 0 1 1-1h2.5Zm2-.25V11h4v-.25a2 2 0 0 0-4 0ZM12 15.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"/>
+              </svg>
+            </span>
+            <input
+              type="password"
+              id="loginPassword"
+              name="password"
+              autocomplete="current-password"
+              placeholder="Digite sua senha"
+              required
+            />
+          </div>
+        </div>
+
+        <p class="login-support" id="loginSupport">A senha é armazenada somente na memória da sessão atual.</p>
+
+        <p id="loginError" class="login-error" role="alert" aria-live="assertive" hidden></p>
+
+        <div class="login-actions">
+          <button type="submit" id="loginSubmit" class="primary login-submit">Entrar</button>
+          <a class="login-help" href="mailto:cefgd.rj@caixa.gov.br">Precisa de ajuda?</a>
+        </div>
+
+        <footer class="login-footer" aria-label="Informações institucionais">
+          <p>CEFGD/RJ – Recuperação de Débitos do FGTS Perante o Empregador</p>
+          <p>Uso exclusivo da equipe de Gestão da Base.</p>
+        </footer>
+      </form>
+    </main>
+  </div>
 
   <script src="js/utils.js"></script>
   <script src="js/auth.js"></script>


### PR DESCRIPTION
## Summary
- refresh the login page layout to match the requested visual design and highlight SIREP branding
- add inline guidance, iconography, and support link while keeping the password capture flow intact

## Testing
- Manual verification: loaded `login.html` via `python -m http.server`

------
https://chatgpt.com/codex/tasks/task_e_68daaabef97c8323ad898d158cc70ae6